### PR TITLE
added columns, filter dependency and conservation category displayed below scientific name

### DIFF
--- a/boranga/components/conservation_status/serializers.py
+++ b/boranga/components/conservation_status/serializers.py
@@ -442,13 +442,15 @@ class ListCommunityConservationStatusSerializer(serializers.ModelSerializer):
         return ''
 
     def get_community_migrated_id(self,obj):
-        if obj.community.taxonomy:
-            return obj.community.taxonomy.community_migrated_id
+        if obj.community:
+            if obj.community.taxonomy:
+                return obj.community.taxonomy.community_migrated_id
         return ''
 
     def get_community_name(self,obj):
-        if obj.community.taxonomy:
-            return obj.community.taxonomy.community_name
+        if obj.community:
+            if obj.community.taxonomy:
+                return obj.community.taxonomy.community_name
         return ''
 
     def get_community_status(self,obj):

--- a/boranga/components/conservation_status/serializers.py
+++ b/boranga/components/conservation_status/serializers.py
@@ -1137,6 +1137,8 @@ class DTConservationStatusReferralSerializer(serializers.ModelSerializer):
     scientific_name = serializers.SerializerMethodField()
     conservation_list = serializers.SerializerMethodField()
     conservation_category = serializers.SerializerMethodField()
+    family = serializers.SerializerMethodField()
+    genus = serializers.SerializerMethodField()
     # community related fields
     community_number = serializers.SerializerMethodField()
     community_migrated_id = serializers.SerializerMethodField()
@@ -1165,6 +1167,8 @@ class DTConservationStatusReferralSerializer(serializers.ModelSerializer):
             'scientific_name',
             'conservation_list',
             'conservation_category',
+            'family',
+            'genus',
             'community_number',
             'community_migrated_id',
             'community_name',
@@ -1236,6 +1240,18 @@ class DTConservationStatusReferralSerializer(serializers.ModelSerializer):
     def get_conservation_category(self,obj):
         if obj.conservation_status.conservation_category:
             return obj.conservation_status.conservation_category.code
+        return ''
+    
+    def get_family(self,obj):
+        if obj.conservation_status.species:
+            if obj.conservation_status.species.taxonomy.family_fk:
+                return obj.conservation_status.species.taxonomy.family_fk.scientific_name
+        return ''
+
+    def get_genus(self,obj):
+        if obj.conservation_status.species:
+            if obj.conservation_status.species.taxonomy.genus:
+                return obj.conservation_status.species.taxonomy.genus.name
         return ''
 
 

--- a/boranga/components/species_and_communities/serializers.py
+++ b/boranga/components/species_and_communities/serializers.py
@@ -522,7 +522,7 @@ class BaseSpeciesSerializer(serializers.ModelSerializer):
 			qs = ConservationStatus.objects.get(
         		species=obj ,
         		conservation_list__applies_to_wa=True,
-        		processing_status='current'
+        		processing_status='approved'
         	)
 			return SpeciesConservationStatusSerializer(qs).data
 		except ConservationStatus.DoesNotExist:
@@ -832,7 +832,7 @@ class BaseCommunitySerializer(serializers.ModelSerializer):
 			qs = ConservationStatus.objects.get(
 				community=obj ,
 				conservation_list__applies_to_wa=True,
-				processing_status='current')
+				processing_status='approved')
 			return CommunityConservationStatusSerializer(qs).data
 		except ConservationStatus.DoesNotExist:
 			return CommunityConservationStatusSerializer().data

--- a/boranga/frontend/boranga/src/components/common/communities_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/communities_dashboard.vue
@@ -78,9 +78,10 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Region:</label>
-                        <select class="form-select" v-model="filterCommunityRegion">
+                        <select class="form-select" v-model="filterCommunityRegion"
+                        @change="filterDistrict($event)">
                             <option value="all">All</option>
-                            <option v-for="region in region_list" :value="region.id">{{region.name}}</option>
+                            <option v-for="region in region_list" :value="region.id" v-bind:key="region.id">{{region.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -89,7 +90,7 @@
                         <label for="">District:</label>
                         <select class="form-select" v-model="filterCommunityDistrict">
                             <option value="all">All</option>
-                            <option v-for="district in district_list" :value="district.id">{{district.name}}</option>
+                            <option v-for="district in filtered_district_list" :value="district.id">{{district.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -228,6 +229,7 @@ export default {
             filterRegionDistrict: {},
             region_list: [],
             district_list: [],
+            filtered_district_list: [],
             
             // filtering options
             external_status:[
@@ -702,6 +704,7 @@ export default {
                 vm.conservation_list_dict = vm.filterListsCommunities.conservation_list_dict;
                 vm.conservation_category_list = vm.filterListsCommunities.conservation_category_list;
                 vm.filterConservationCategory();
+                vm.filterDistrict();
                 vm.community_status = vm.internal_status;
             },(error) => {
                 console.log(error);
@@ -727,6 +730,23 @@ export default {
                         {
                           this.filtered_conservation_category_list.push(choice);
                         }
+                    }
+                });
+        },
+         //-------filter district dropdown dependent on region selected
+         filterDistrict: function(event) {
+                this.$nextTick(() => {
+                    if(event){
+                      this.filterCommunityDistrict='all'; //-----to remove the previous selection
+                    }
+                    this.filtered_district_list=[];
+                    //---filter districts as per region selected
+                    for(let choice of this.district_list){
+                        if(choice.region_id.toString() === this.filterCommunityRegion.toString())
+                        {
+                          this.filtered_district_list.push(choice);
+                        }
+                        
                     }
                 });
         },

--- a/boranga/frontend/boranga/src/components/common/conservation_status_community_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/conservation_status_community_dashboard.vue
@@ -64,9 +64,10 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Region:</label>
-                        <select class="form-select" v-model="filterCSCommunityRegion">
+                        <select class="form-select" v-model="filterCSCommunityRegion"
+                        @change="filterDistrict($event)">
                             <option value="all">All</option>
-                            <option v-for="region in region_list" :value="region.id">{{region.name}}</option>
+                            <option v-for="region in region_list" :value="region.id" v-bind:key="region.id">{{region.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -75,7 +76,7 @@
                         <label for="">District:</label>
                         <select class="form-select" v-model="filterCSCommunityDistrict">
                             <option value="all">All</option>
-                            <option v-for="district in district_list" :value="district.id">{{district.name}}</option>
+                            <option v-for="district in filtered_district_list" :value="district.id">{{district.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -247,6 +248,7 @@ export default {
             filterRegionDistrict: {},
             region_list: [],
             district_list: [],
+            filtered_district_list: [],
             
             // filtering options
             external_status:[
@@ -799,6 +801,7 @@ export default {
                 vm.conservation_list_dict = vm.filterListsCommunities.conservation_list_dict;
                 vm.conservation_category_list = vm.filterListsCommunities.conservation_category_list;
                 vm.filterConservationCategory();
+                vm.filterDistrict();
                 vm.proposal_status = vm.internal_status;
                 //vm.proposal_status = vm.level == 'internal' ? response.body.processing_status_choices: response.body.customer_status_choices;
                 //vm.proposal_status = vm.level == 'internal' ? vm.internal_status: vm.external_status;
@@ -826,6 +829,23 @@ export default {
                         {
                           this.filtered_conservation_category_list.push(choice);
                         }
+                    }
+                });
+        },
+         //-------filter district dropdown dependent on region selected
+         filterDistrict: function(event) {
+                this.$nextTick(() => {
+                    if(event){
+                      this.filterCSCommunityDistrict='all'; //-----to remove the previous selection
+                    }
+                    this.filtered_district_list=[];
+                    //---filter districts as per region selected
+                    for(let choice of this.district_list){
+                        if(choice.region_id.toString() === this.filterCSCommunityRegion.toString())
+                        {
+                          this.filtered_district_list.push(choice);
+                        }
+                        
                     }
                 });
         },

--- a/boranga/frontend/boranga/src/components/common/conservation_status_fauna_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/conservation_status_fauna_dashboard.vue
@@ -83,9 +83,10 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Region:</label>
-                        <select class="form-select" v-model="filterCSFaunaRegion">
+                        <select class="form-select" v-model="filterCSFaunaRegion"
+                        @change="filterDistrict($event)">
                             <option value="all">All</option>
-                            <option v-for="region in region_list" :value="region.id">{{region.name}}</option>
+                            <option v-for="region in region_list" :value="region.id" v-bind:key="region.id">{{region.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -94,7 +95,7 @@
                         <label for="">District:</label>
                         <select class="form-select" v-model="filterCSFaunaDistrict">
                             <option value="all">All</option>
-                            <option v-for="district in district_list" :value="district.id">{{district.name}}</option>
+                            <option v-for="district in filtered_district_list" :value="district.id">{{district.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -291,6 +292,7 @@ export default {
             filterRegionDistrict: {},
             region_list: [],
             district_list: [],
+            filtered_district_list: [],
             
             // filtering options
             external_status:[
@@ -998,6 +1000,7 @@ export default {
                 vm.conservation_list_dict = vm.filterListsSpecies.conservation_list_dict;
                 vm.conservation_category_list = vm.filterListsSpecies.conservation_category_list;
                 vm.filterConservationCategory();
+                vm.filterDistrict();
                 vm.proposal_status = vm.internal_status;
                 //vm.proposal_status = vm.level == 'internal' ? response.body.processing_status_choices: response.body.customer_status_choices;
                 //vm.proposal_status = vm.level == 'internal' ? vm.internal_status: vm.external_status;
@@ -1027,6 +1030,23 @@ export default {
                         }
                     }
                 //});
+        },
+         //-------filter district dropdown dependent on region selected
+         filterDistrict: function(event) {
+                this.$nextTick(() => {
+                    if(event){
+                      this.filterCSFaunaDistrict='all'; //-----to remove the previous selection
+                    }
+                    this.filtered_district_list=[];
+                    //---filter districts as per region selected
+                    for(let choice of this.district_list){
+                        if(choice.region_id.toString() === this.filterCSFaunaRegion.toString())
+                        {
+                          this.filtered_district_list.push(choice);
+                        }
+                        
+                    }
+                });
         },
         createFaunaConservationStatus: async function () {
             let newFaunaCSId = null

--- a/boranga/frontend/boranga/src/components/common/conservation_status_flora_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/conservation_status_flora_dashboard.vue
@@ -73,9 +73,10 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Region:</label>
-                        <select class="form-select" v-model="filterCSFloraRegion">
+                        <select class="form-select" v-model="filterCSFloraRegion"
+                        @change="filterDistrict($event)">
                             <option value="all">All</option>
-                            <option v-for="region in region_list" :value="region.id">{{region.name}}</option>
+                            <option v-for="region in region_list" :value="region.id" v-bind:key="region.id">{{region.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -84,7 +85,7 @@
                         <label for="">District:</label>
                         <select class="form-select" v-model="filterCSFloraDistrict">
                             <option value="all">All</option>
-                            <option v-for="district in district_list" :value="district.id">{{district.name}}</option>
+                            <option v-for="district in filtered_district_list" :value="district.id">{{district.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -274,6 +275,7 @@ export default {
             filterRegionDistrict: {},
             region_list: [],
             district_list: [],
+            filtered_district_list: [],
             
             // filtering options
             external_status:[
@@ -937,6 +939,7 @@ export default {
                 vm.conservation_list_dict = vm.filterListsSpecies.conservation_list_dict;
                 vm.conservation_category_list = vm.filterListsSpecies.conservation_category_list;
                 vm.filterConservationCategory();
+                vm.filterDistrict();
                 vm.proposal_status = vm.internal_status;
                 //vm.proposal_status = vm.level == 'internal' ? response.body.processing_status_choices: response.body.customer_status_choices;
                 //vm.proposal_status = vm.level == 'internal' ? vm.internal_status: vm.external_status;
@@ -966,6 +969,23 @@ export default {
                         }
                     }
                 //});
+        },
+         //-------filter district dropdown dependent on region selected
+         filterDistrict: function(event) {
+                this.$nextTick(() => {
+                    if(event){
+                      this.filterCSFloraDistrict='all'; //-----to remove the previous selection
+                    }
+                    this.filtered_district_list=[];
+                    //---filter districts as per region selected
+                    for(let choice of this.district_list){
+                        if(choice.region_id.toString() === this.filterCSFloraRegion.toString())
+                        {
+                          this.filtered_district_list.push(choice);
+                        }
+                        
+                    }
+                });
         },
         createFloraConservationStatus: async function () {
             let newFloraCSId = null

--- a/boranga/frontend/boranga/src/components/common/cs_community_referrals_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/cs_community_referrals_dashboard.vue
@@ -78,9 +78,10 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Region:</label>
-                        <select class="form-select" v-model="filterCSRefCommunityRegion">
+                        <select class="form-select" v-model="filterCSRefCommunityRegion"
+                        @change="filterDistrict($event)">
                             <option value="all">All</option>
-                            <option v-for="region in region_list" :value="region.id">{{region.name}}</option>
+                            <option v-for="region in region_list" :value="region.id" v-bind:key="region.id">{{region.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -89,7 +90,7 @@
                         <label for="">District:</label>
                         <select class="form-select" v-model="filterCSRefCommunityDistrict">
                             <option value="all">All</option>
-                            <option v-for="district in district_list" :value="district.id">{{district.name}}</option>
+                            <option v-for="district in filtered_district_list" :value="district.id">{{district.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -215,7 +216,7 @@ export default {
             region_list: [],
             district_list: [],
             proposal_status: [],
-
+            filtered_district_list: [],
         }
     },
     components:{
@@ -290,7 +291,7 @@ export default {
             }
         },
         datatable_headers: function(){
-           return ['Number', 'Community','Community Id' ,'Community Name', 'Conservation List' , 'Conservation Category',      /*'Region', 'District',*/ 'Status', 'Action']
+           return ['Number', 'Community','Community Id' ,'Community Name', 'Conservation List' , 'Conservation Category', 'Family', 'Genera', /*'Region', 'District',*/ 'Status', 'Action']
         },
         column_number: function(){
             return {
@@ -393,6 +394,34 @@ export default {
                 name: "conservation_status__conservation_category__code",
             }
         },
+        column_family: function(){
+            return {
+                data: "family",
+                orderable: true,
+                searchable: true,
+                visible: true,
+                'render': function(value, type){
+                    let result = helpers.dtPopover(value, 30, 'hover');
+                    return type=='export' ? value : result;
+                },
+                //'createdCell': helpers.dtPopoverCellFn,
+                name: "species__taxonomy__family__name",
+            }
+        },
+        column_genera: function(){
+            return {
+                data: "genus",
+                orderable: true,
+                searchable: true,
+                visible: true,
+                'render': function(value, type){
+                    let result = helpers.dtPopover(value, 30, 'hover');
+                    return type=='export' ? value : result;
+                },
+                //'createdCell': helpers.dtPopoverCellFn,
+                name: "species__taxonomy__genus__name",
+            }
+        },
         column_status: function(){
             return {
                 data: "processing_status",
@@ -488,6 +517,8 @@ export default {
                 /*vm.column_community_status,*/
                 vm.column_conservation_list,
                 vm.column_conservation_category,
+                vm.column_family,
+                vm.column_genera,
                 /*vm.column_region,
                 vm.column_district,*/
                 vm.column_status,
@@ -654,6 +685,7 @@ export default {
                 vm.conservation_list_dict = vm.filterListsCommunities.conservation_list_dict;
                 vm.conservation_category_list = vm.filterListsCommunities.conservation_category_list;
                 vm.filterConservationCategory();
+                vm.filterDistrict();
                 vm.proposal_status = vm.filterListsCommunities.processing_status_list
             },(error) => {
                 console.log(error);
@@ -679,6 +711,23 @@ export default {
                         {
                           this.filtered_conservation_category_list.push(choice);
                         }
+                    }
+                });
+        },
+          //-------filter district dropdown dependent on region selected
+          filterDistrict: function(event) {
+                this.$nextTick(() => {
+                    if(event){
+                      this.filterCSRefCommunityDistrict='all'; //-----to remove the previous selection
+                    }
+                    this.filtered_district_list=[];
+                    //---filter districts as per region selected
+                    for(let choice of this.district_list){
+                        if(choice.region_id.toString() === this.filterCSRefCommunityRegion.toString())
+                        {
+                          this.filtered_district_list.push(choice);
+                        }
+                        
                     }
                 });
         },

--- a/boranga/frontend/boranga/src/components/common/cs_fauna_referrals_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/cs_fauna_referrals_dashboard.vue
@@ -110,9 +110,10 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Region:</label>
-                        <select class="form-select" v-model="filterCSRefFaunaRegion">
+                        <select class="form-select" v-model="filterCSRefFaunaRegion"
+                        @change="filterDistrict($event)">
                             <option value="all">All</option>
-                            <option v-for="region in region_list" :value="region.id">{{region.name}}</option>
+                            <option v-for="region in region_list" :value="region.id" v-bind:key="region.id">{{region.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -121,7 +122,7 @@
                         <label for="">District:</label>
                         <select class="form-select" v-model="filterCSRefFaunaDistrict">
                             <option value="all">All</option>
-                            <option v-for="district in district_list" :value="district.id">{{district.name}}</option>
+                            <option v-for="district in filtered_district_list" :value="district.id">{{district.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -273,6 +274,7 @@ export default {
             region_list: [],
             district_list: [],
             proposal_status: [],
+            filtered_district_list: [],
         }
     },
     components:{
@@ -356,7 +358,7 @@ export default {
         },
         datatable_headers: function(){
             return ['Number','Species','Scientific Name','Conservation List', 
-                    'Conservation Category'/*, 'Region', 'District'*/,'Status', 'Action']
+                    'Conservation Category', 'Family', 'Genera' /*, 'Region', 'District'*/,'Status', 'Action']
         },
         column_number: function(){
             return {
@@ -447,6 +449,34 @@ export default {
                     return ''
                 },
                 name: "conservation_status__conservation_category__code",
+            }
+        },
+        column_family: function(){
+            return {
+                data: "family",
+                orderable: true,
+                searchable: true,
+                visible: true,
+                'render': function(value, type){
+                    let result = helpers.dtPopover(value, 30, 'hover');
+                    return type=='export' ? value : result;
+                },
+                //'createdCell': helpers.dtPopoverCellFn,
+                name: "species__taxonomy__family__name",
+            }
+        },
+        column_genera: function(){
+            return {
+                data: "genus",
+                orderable: true,
+                searchable: true,
+                visible: true,
+                'render': function(value, type){
+                    let result = helpers.dtPopover(value, 30, 'hover');
+                    return type=='export' ? value : result;
+                },
+                //'createdCell': helpers.dtPopoverCellFn,
+                name: "species__taxonomy__genus__name",
             }
         },
         column_status: function(){
@@ -541,11 +571,11 @@ export default {
                 vm.column_number,
                 vm.column_species_number,
                 vm.column_scientific_name,
-                /*vm.column_common_name,
-                vm.column_family,
-                vm.column_genera,*/
+                /*vm.column_common_name,*/
                 vm.column_conservation_list,
                 vm.column_conservation_category,
+                vm.column_family,
+                vm.column_genera,
                 /*vm.column_region,
                 vm.column_district,*/
                 vm.column_status,
@@ -836,6 +866,7 @@ export default {
                 vm.conservation_list_dict = vm.filterListsSpecies.conservation_list_dict;
                 vm.conservation_category_list = vm.filterListsSpecies.conservation_category_list;
                 vm.filterConservationCategory();
+                vm.filterDistrict();
                 vm.proposal_status = vm.filterListsSpecies.processing_status_list;
             },(error) => {
                 console.log(error);
@@ -863,6 +894,23 @@ export default {
                         }
                     }
                 //});
+        },
+         //-------filter district dropdown dependent on region selected
+         filterDistrict: function(event) {
+                this.$nextTick(() => {
+                    if(event){
+                      this.filterCSRefFaunaDistrict='all'; //-----to remove the previous selection
+                    }
+                    this.filtered_district_list=[];
+                    //---filter districts as per region selected
+                    for(let choice of this.district_list){
+                        if(choice.region_id.toString() === this.filterCSRefFaunaRegion.toString())
+                        {
+                          this.filtered_district_list.push(choice);
+                        }
+                        
+                    }
+                });
         },
         addEventListeners: function(){
             let vm = this;

--- a/boranga/frontend/boranga/src/components/common/cs_flora_referrals_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/cs_flora_referrals_dashboard.vue
@@ -94,9 +94,10 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Region:</label>
-                        <select class="form-select" v-model="filterCSRefFloraRegion">
+                        <select class="form-select" v-model="filterCSRefFloraRegion"
+                        @change="filterDistrict($event)">
                             <option value="all">All</option>
-                            <option v-for="region in region_list" :value="region.id">{{region.name}}</option>
+                            <option v-for="region in region_list" :value="region.id" v-bind:key="region.id">{{region.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -105,7 +106,7 @@
                         <label for="">District:</label>
                         <select class="form-select" v-model="filterCSRefFloraDistrict">
                             <option value="all">All</option>
-                            <option v-for="district in district_list" :value="district.id">{{district.name}}</option>
+                            <option v-for="district in filtered_district_list" :value="district.id">{{district.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -249,6 +250,7 @@ export default {
             region_list: [],
             district_list: [],
             proposal_status: [],
+            filtered_district_list: [],
         }
     },
     components:{
@@ -326,7 +328,7 @@ export default {
         },
         datatable_headers: function(){
             return ['Number','Species','Scientific Name','Conservation List', 
-                    'Conservation Category'/*, 'Region', 'District'*/,'Status', 'Action']
+            'Conservation Category', 'Family', 'Genera' /*, 'Region', 'District'*/, 'Status', 'Action']
         },
         column_number: function(){
             return {
@@ -417,6 +419,34 @@ export default {
                     return ''
                 },
                 name: "conservation_status__conservation_category__code",
+            }
+        },
+        column_family: function(){
+            return {
+                data: "family",
+                orderable: true,
+                searchable: true,
+                visible: true,
+                'render': function(value, type){
+                    let result = helpers.dtPopover(value, 30, 'hover');
+                    return type=='export' ? value : result;
+                },
+                //'createdCell': helpers.dtPopoverCellFn,
+                name: "species__taxonomy__family__name",
+            }
+        },
+        column_genera: function(){
+            return {
+                data: "genus",
+                orderable: true,
+                searchable: true,
+                visible: true,
+                'render': function(value, type){
+                    let result = helpers.dtPopover(value, 30, 'hover');
+                    return type=='export' ? value : result;
+                },
+                //'createdCell': helpers.dtPopoverCellFn,
+                name: "species__taxonomy__genus__name",
             }
         },
         column_status: function(){
@@ -512,11 +542,11 @@ export default {
                 vm.column_number,
                 vm.column_species_number,
                 vm.column_scientific_name,
-                /*vm.column_common_name,
-                vm.column_family,
-                vm.column_genera,*/
+                /*vm.column_common_name,*/
                 vm.column_conservation_list,
                 vm.column_conservation_category,
+                vm.column_family,
+                vm.column_genera,
                 /*vm.column_region,
                 vm.column_district,*/
                 vm.column_status,
@@ -767,6 +797,7 @@ export default {
                 vm.conservation_list_dict = vm.filterListsSpecies.conservation_list_dict;
                 vm.conservation_category_list = vm.filterListsSpecies.conservation_category_list;
                 vm.filterConservationCategory();
+                vm.filterDistrict();
                 vm.proposal_status = vm.filterListsSpecies.processing_status_list;
             },(error) => {
                 console.log(error);
@@ -794,6 +825,23 @@ export default {
                         }
                     }
                 //});
+        },
+         //-------filter district dropdown dependent on region selected
+         filterDistrict: function(event) {
+                this.$nextTick(() => {
+                    if(event){
+                      this.filterCSRefFloraDistrict='all'; //-----to remove the previous selection
+                    }
+                    this.filtered_district_list=[];
+                    //---filter districts as per region selected
+                    for(let choice of this.district_list){
+                        if(choice.region_id.toString() === this.filterCSRefFloraRegion.toString())
+                        {
+                          this.filtered_district_list.push(choice);
+                        }
+                        
+                    }
+                });
         },
         addEventListeners: function(){
             let vm = this;

--- a/boranga/frontend/boranga/src/components/common/species_fauna_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/species_fauna_dashboard.vue
@@ -93,9 +93,10 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Region:</label>
-                        <select class="form-select" v-model="filterFaunaRegion">
+                        <select class="form-select" v-model="filterFaunaRegion"
+                        @change="filterDistrict($event)">
                             <option value="all">All</option>
-                            <option v-for="region in region_list" :value="region.id">{{region.name}}</option>
+                            <option v-for="region in region_list" :value="region.id"  v-bind:key="region.id">{{region.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -104,7 +105,7 @@
                         <label for="">District:</label>
                         <select class="form-select" v-model="filterFaunaDistrict">
                             <option value="all">All</option>
-                            <option v-for="district in district_list" :value="district.id">{{district.name}}</option>
+                            <option v-for="district in filtered_district_list" :value="district.id">{{district.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -268,6 +269,7 @@ export default {
             filterRegionDistrict: {},
             region_list: [],
             district_list: [],
+            filtered_district_list: [],
 
             // filtering options
             external_status:[
@@ -936,6 +938,7 @@ export default {
                 vm.conservation_list_dict = vm.filterListsSpecies.conservation_list_dict;
                 vm.conservation_category_list = vm.filterListsSpecies.conservation_category_list;
                 vm.filterConservationCategory();
+                vm.filterDistrict();
                 vm.species_status = vm.internal_status;
             },(error) => {
                 console.log(error);
@@ -961,6 +964,23 @@ export default {
                         {
                           this.filtered_conservation_category_list.push(choice);
                         }
+                    }
+                });
+        },
+         //-------filter district dropdown dependent on region selected
+         filterDistrict: function(event) {
+                this.$nextTick(() => {
+                    if(event){
+                      this.filterFaunaDistrict='all'; //-----to remove the previous selection
+                    }
+                    this.filtered_district_list=[];
+                    //---filter districts as per region selected
+                    for(let choice of this.district_list){
+                        if(choice.region_id.toString() === this.filterFaunaRegion.toString())
+                        {
+                          this.filtered_district_list.push(choice);
+                        }
+                        
                     }
                 });
         },

--- a/boranga/frontend/boranga/src/components/common/species_flora_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/species_flora_dashboard.vue
@@ -110,9 +110,10 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Region:</label>
-                        <select class="form-select" v-model="filterFloraRegion">
+                        <select class="form-select" v-model="filterFloraRegion"
+                        @change="filterDistrict($event)">
                             <option value="all">All</option>
-                            <option v-for="region in region_list" :value="region.id">{{region.name}}</option>
+                            <option v-for="region in region_list" :value="region.id" v-bind:key="region.id">{{region.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -121,7 +122,7 @@
                         <label for="">District:</label>
                         <select class="form-select" v-model="filterFloraDistrict">
                             <option value="all">All</option>
-                            <option v-for="district in district_list" :value="district.id">{{district.name}}</option>
+                            <option v-for="district in filtered_district_list" :value="district.id">{{district.name}}</option>
                         </select>
                     </div>
                 </div>
@@ -290,6 +291,7 @@ export default {
             filterRegionDistrict: {},
             region_list: [],
             district_list: [],
+            filtered_district_list: [],
             
             // filtering options
             external_status:[
@@ -963,6 +965,7 @@ export default {
                 vm.conservation_list_dict = vm.filterListsSpecies.conservation_list_dict;
                 vm.conservation_category_list = vm.filterListsSpecies.conservation_category_list;
                 vm.filterConservationCategory();
+                vm.filterDistrict();
                 vm.species_status = vm.internal_status;
             },(error) => {
                 console.log(error);
@@ -988,6 +991,23 @@ export default {
                         {
                           this.filtered_conservation_category_list.push(choice);
                         }
+                    }
+                });
+        },
+        //-------filter district dropdown dependent on region selected
+        filterDistrict: function(event) {
+                this.$nextTick(() => {
+                    if(event){
+                      this.filterFloraDistrict='all'; //-----to remove the previous selection
+                    }
+                    this.filtered_district_list=[];
+                    //---filter districts as per region selected
+                    for(let choice of this.district_list){
+                        if(choice.region_id.toString() === this.filterFloraRegion.toString())
+                        {
+                          this.filtered_district_list.push(choice);
+                        }
+                        
                     }
                 });
         },


### PR DESCRIPTION
-> added columns 'Family' and 'Genera' to Conservation Status referral dashboards
-> added filter dependency - district dropdown values should only populate if region selected (under Species & Communities and Conservation Status both dash)
-> conservation_category for resp. species/comm is now visible below scientific_name when 'View' that species/comm (if conservation status is 'approved' and 'applies_to_wa=True' for that species/comm)