### PR TITLE
Private Media Permissions

### DIFF
--- a/boranga/components/conservation_status/email.py
+++ b/boranga/components/conservation_status/email.py
@@ -4,12 +4,14 @@ from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.utils.encoding import smart_text
 from django.urls import reverse
 from django.conf import settings
-from django.core.files.storage import default_storage
+#from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 
 from boranga.components.emails.emails import TemplateEmailBase
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 from datetime import datetime
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +189,8 @@ def _log_conservation_status_email(email_message, cs_proposal, sender=None, file
     if file_bytes and filename:
         # attach the file to the comms_log also
         path_to_file = '{}/conservation_status/{}/communications/{}'.format(settings.MEDIA_APP_DIR, cs_proposal.id, filename)
-        path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        #path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        path = private_storage.save(path_to_file, ContentFile(file_bytes))
         email_entry.documents.get_or_create(_file=path_to_file, name=filename)
 
     return email_entry

--- a/boranga/components/occurrence/email.py
+++ b/boranga/components/occurrence/email.py
@@ -4,9 +4,9 @@ from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.utils.encoding import smart_text
 from django.urls import reverse
 from django.conf import settings
-from django.core.files.storage import default_storage
+#from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
-
+from boranga.components.occurrence.models import private_storage
 from boranga.components.emails.emails import TemplateEmailBase
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 from datetime import datetime
@@ -136,7 +136,8 @@ def _log_occurrence_report_email(email_message, ocr_proposal, sender=None, file_
     if file_bytes and filename:
         # attach the file to the comms_log also
         path_to_file = '{}/occurrence_report/{}/communications/{}'.format(settings.MEDIA_APP_DIR, ocr_proposal.id, filename)
-        path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        #path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        path = private_storage.save(path_to_file, ContentFile(file_bytes))
         email_entry.documents.get_or_create(_file=path_to_file, name=filename)
 
     return email_entry

--- a/boranga/components/proposals/email.py
+++ b/boranga/components/proposals/email.py
@@ -5,11 +5,13 @@ from django.utils.encoding import smart_text
 #from django.core.urlresolvers import reverse
 from django.urls import reverse
 from django.conf import settings
-from django.core.files.storage import default_storage
+#from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 
 from boranga.components.emails.emails import TemplateEmailBase
 from datetime import datetime
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
 
 logger = logging.getLogger(__name__)
 
@@ -769,7 +771,8 @@ def _log_proposal_email(email_message, proposal, sender=None, file_bytes=None, f
     if file_bytes and filename:
         # attach the file to the comms_log also
         path_to_file = '{}/proposals/{}/communications/{}'.format(settings.MEDIA_APP_DIR, proposal.id, filename)
-        path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        #path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        path = private_storage.save(path_to_file, ContentFile(file_bytes))
         email_entry.documents.get_or_create(_file=path_to_file, name=filename)
 
     return email_entry

--- a/boranga/components/species_and_communities/email.py
+++ b/boranga/components/species_and_communities/email.py
@@ -4,9 +4,9 @@ from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.utils.encoding import smart_text
 from django.urls import reverse
 from django.conf import settings
-from django.core.files.storage import default_storage
+#from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
-
+from boranga.components.species_and_communities.models import private_storage
 from boranga.components.emails.emails import TemplateEmailBase
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 from datetime import datetime
@@ -308,7 +308,8 @@ def _log_species_email(email_message, species_proposal, sender=None, file_bytes=
     if file_bytes and filename:
         # attach the file to the comms_log also
         path_to_file = '{}/species/{}/communications/{}'.format(settings.MEDIA_APP_DIR, species_proposal.id, filename)
-        path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        #path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        path = private_storage.save(path_to_file, ContentFile(file_bytes))
         email_entry.documents.get_or_create(_file=path_to_file, name=filename)
 
     return email_entry
@@ -361,7 +362,8 @@ def _log_community_email(email_message, community_proposal, sender=None, file_by
     if file_bytes and filename:
         # attach the file to the comms_log also
         path_to_file = '{}/community/{}/communications/{}'.format(settings.MEDIA_APP_DIR, community_proposal.id, filename)
-        path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        #path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        path = private_storage.save(path_to_file, ContentFile(file_bytes))
         email_entry.documents.get_or_create(_file=path_to_file, name=filename)
 
     return email_entry

--- a/boranga/helpers.py
+++ b/boranga/helpers.py
@@ -73,7 +73,6 @@ def is_species_processor(user_id):
 def is_community_processor(user_id):
     if isinstance(user_id, EmailUser) or isinstance(user_id, EmailUserRO):
         user_id = user_id.id
-    print("USER ID",user_id)
     community_group = SystemGroup.objects.get(name=GROUP_NAME_SPECIES_COMMUNITIES_PROCESSOR)
     return True if user_id in community_group.get_system_group_member_ids() else False
 

--- a/boranga/helpers.py
+++ b/boranga/helpers.py
@@ -73,6 +73,7 @@ def is_species_processor(user_id):
 def is_community_processor(user_id):
     if isinstance(user_id, EmailUser) or isinstance(user_id, EmailUserRO):
         user_id = user_id.id
+    print("USER ID",user_id)
     community_group = SystemGroup.objects.get(name=GROUP_NAME_SPECIES_COMMUNITIES_PROCESSOR)
     return True if user_id in community_group.get_system_group_member_ids() else False
 

--- a/boranga/views.py
+++ b/boranga/views.py
@@ -347,14 +347,24 @@ def is_authorised_to_access_document(request):
             return is_authorised_to_access_occurrence_report_document(request,o_document_id)
     
         #conservation status
-        c_document_id = get_file_path_id("conservation_status",request.path)
-        if c_document_id:
-            return is_authorised_to_access_conservation_status_document(request,c_document_id)
+        cs_document_id = get_file_path_id("conservation_status",request.path)
+        if cs_document_id:
+            return is_authorised_to_access_conservation_status_document(request,cs_document_id)
 
         #meeting
         m_document_id = get_file_path_id("meeting",request.path)
         if m_document_id:
             return is_authorised_to_access_meeting_document(request,m_document_id)
+        
+        #species
+        s_document_id = get_file_path_id("species",request.path)
+        if s_document_id:
+            return is_authorised_to_access_species_document(request,s_document_id)
+        
+        #community
+        c_document_id = get_file_path_id("community",request.path)
+        if c_document_id:
+            return is_authorised_to_access_community_document(request,c_document_id)
 
         return False
 

--- a/boranga/views.py
+++ b/boranga/views.py
@@ -265,7 +265,7 @@ def is_authorised_to_access_community_document(request,document_id):
             is_django_admin(request) or
             is_assessor(request) or
             is_approver(request) or
-            is_community_processor
+            is_community_processor(request)
         )
 
 def is_authorised_to_access_species_document(request,document_id):

--- a/boranga/views.py
+++ b/boranga/views.py
@@ -263,9 +263,9 @@ def is_authorised_to_access_community_document(request,document_id):
             request.user.is_superuser or
             is_boranga_admin(request) or
             is_django_admin(request) or
-            is_assessor(request) or
-            is_approver(request) or
-            is_community_processor(request)
+            is_assessor(request.user) or
+            is_approver(request.user) or
+            is_community_processor(request.user)
         )
 
 def is_authorised_to_access_species_document(request,document_id):
@@ -275,9 +275,9 @@ def is_authorised_to_access_species_document(request,document_id):
             request.user.is_superuser or
             is_boranga_admin(request) or
             is_django_admin(request) or
-            is_assessor(request) or
-            is_approver(request) or
-            is_species_processor(request)
+            is_assessor(request.user) or
+            is_approver(request.user) or
+            is_species_processor(request.user)
         )
 
 def is_authorised_to_access_meeting_document(request,document_id):
@@ -289,9 +289,9 @@ def is_authorised_to_access_meeting_document(request,document_id):
             is_django_admin(request) or
             is_assessor(request) or
             is_approver(request) or
-            is_species_processor(request) or
-            is_community_processor(request) or
-            is_conservation_status_editor(request) or
+            is_species_processor(request.user) or
+            is_community_processor(request.user) or
+            is_conservation_status_editor(request.user) or
             is_conservation_status_referee(request)
         )
 
@@ -302,8 +302,8 @@ def is_authorised_to_access_occurrence_report_document(request,document_id):
             request.user.is_superuser or
             is_boranga_admin(request) or
             is_django_admin(request) or
-            is_assessor(request) or
-            is_approver(request)
+            is_assessor(request.user) or
+            is_approver(request.user)
         )
     elif is_customer(request):
         user = request.user
@@ -317,9 +317,9 @@ def is_authorised_to_access_conservation_status_document(request,document_id):
             request.user.is_superuser or
             is_boranga_admin(request) or
             is_django_admin(request) or
-            is_assessor(request) or
-            is_approver(request) or
-            is_conservation_status_editor(request) or
+            is_assessor(request.user) or
+            is_approver(request.user) or
+            is_conservation_status_editor(request.user) or
             is_conservation_status_referee(request)
         )
     elif is_customer(request):


### PR DESCRIPTION
Added authorisation to private media documents and made some minor fixes.

All known filepaths have auth checks based on the model their documentation pertains to. for both internal and external users.

External users can access certain documents that they have submitted. Internal users may access any document as long as they belong to at least one of the required auth groups. Each document/model type has its own auth check function that use a number of existing helper functions to determine authorisation.

Some media storage was still using default storage, these instances were switched to use private.
The getPrivateFile view was adjusted to normalise and validate the file paths for security.

Note: internal document access will be subject to review and any additional document sub-directories will need to be accounted for.