### PR TITLE
Validation message change

### DIFF
--- a/boranga/frontend/boranga/src/components/external/conservation_status/conservation_status_proposal.vue
+++ b/boranga/frontend/boranga/src/components/external/conservation_status/conservation_status_proposal.vue
@@ -440,12 +440,12 @@ export default {
       let blank_fields=[]
       if (vm.conservation_status_obj.group_type == 'flora' || vm.conservation_status_obj.group_type == 'fauna'){
         if (vm.conservation_status_obj.species_id == null || vm.conservation_status_obj.species_id == ''){
-            blank_fields.push(' Species is missing')
+            blank_fields.push(' Scientific Name is missing')
         }
       }
       else{
         if (vm.conservation_status_obj.community_id == null || vm.conservation_status_obj.community_id == ''){
-            blank_fields.push(' Community is missing')
+            blank_fields.push(' Community Name is missing')
         }
       }
       if(check_action == "submit"){

--- a/boranga/frontend/boranga/src/components/external/occurrence/occurrence_report_proposal.vue
+++ b/boranga/frontend/boranga/src/components/external/occurrence/occurrence_report_proposal.vue
@@ -433,12 +433,12 @@ export default {
             let blank_fields = []
             if (vm.occurrence_report_obj.group_type == 'flora' || vm.occurrence_report_obj.group_type == 'fauna') {
                 if (vm.occurrence_report_obj.species_id == null || vm.occurrence_report_obj.species_id == '') {
-                    blank_fields.push(' Species is missing')
+                    blank_fields.push(' Scientific Name is missing')
                 }
             }
             else {
                 if (vm.occurrence_report_obj.community_id == null || vm.occurrence_report_obj.community_id == '') {
-                    blank_fields.push(' Community is missing')
+                    blank_fields.push(' Community Name is missing')
                 }
             }
             if (check_action == "submit") {

--- a/boranga/frontend/boranga/src/components/internal/conservation_status/conservation_status.vue
+++ b/boranga/frontend/boranga/src/components/internal/conservation_status/conservation_status.vue
@@ -673,12 +673,12 @@ export default {
             let blank_fields=[]
             if (vm.conservation_status_obj.group_type == 'flora' || vm.conservation_status_obj.group_type == 'fauna'){
                 if (vm.conservation_status_obj.species_id == null || vm.conservation_status_obj.species_id == ''){
-                    blank_fields.push(' Species is missing')
+                    blank_fields.push(' Scientific Name is missing')
                 }
             }
             else{
                 if (vm.conservation_status_obj.community_id == null || vm.conservation_status_obj.community_id == ''){
-                    blank_fields.push(' Community is missing')
+                    blank_fields.push(' Community Name is missing')
                 }
             }
             if(check_action == "submit"){


### PR DESCRIPTION
Change for Conservation Status and Occurrence Report validation message. Instead of reporting that the "Species is missing" or "Community is missing", it reports directly on the field with "Scientific Name is missing" or "Community Name is missing".