### PR TITLE
First time log in check

### DIFF
--- a/boranga/settings.py
+++ b/boranga/settings.py
@@ -152,7 +152,7 @@ REST_FRAMEWORK = {
 
 MIDDLEWARE_CLASSES += [
     # 'boranga.middleware.BookingTimerMiddleware',
-    # 'boranga.middleware.FirstTimeNagScreenMiddleware',
+    "boranga.middleware.FirstTimeNagScreenMiddleware",
     # 'boranga.middleware.RevisionOverrideMiddleware',
     "whitenoise.middleware.WhiteNoiseMiddleware",
 ]


### PR DESCRIPTION
If the user is missing contact, name, or address details they will be redirected to a first-time login page so they can fill in those details.

Works exactly the same as leases-licensing.