### PR TITLE
Threat Adjustments

### DIFF
--- a/boranga/components/occurrence/serializers.py
+++ b/boranga/components/occurrence/serializers.py
@@ -1694,6 +1694,7 @@ class OCCConservationThreatSerializer(serializers.ModelSerializer):
     potential_impact_name = serializers.SerializerMethodField()
     potential_threat_onset_name = serializers.SerializerMethodField()
     original_report = serializers.SerializerMethodField()
+    original_threat = serializers.SerializerMethodField()
 
     class Meta:
         model = OCCConservationThreat
@@ -1715,7 +1716,8 @@ class OCCConservationThreatSerializer(serializers.ModelSerializer):
             "source",
             "occurrence",
             "visible",
-            "original_report"
+            "original_report",
+            "original_threat"
         )
         read_only_fields = (
             "id",
@@ -1746,6 +1748,9 @@ class OCCConservationThreatSerializer(serializers.ModelSerializer):
         if obj.occurrence_report_threat:
             return obj.occurrence_report_threat.occurrence_report.occurrence_report_number
 
+    def get_original_threat(self, obj):
+        if obj.occurrence_report_threat:
+            return obj.occurrence_report_threat.threat_number
 
 class SaveOCCConservationThreatSerializer(serializers.ModelSerializer):
 

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -119,6 +119,8 @@ from boranga.components.species_and_communities.serializers import (
     CommunityLogEntrySerializer,
     CommunityUserActionSerializer,
 )
+from boranga.components.occurrence.models import Occurrence, OCCConservationThreat
+from boranga.components.occurrence.serializers import OCCConservationThreatSerializer
 
                             
 
@@ -993,6 +995,24 @@ class SpeciesViewSet(viewsets.ModelViewSet):
         res_json = json.dumps(related_type) 
         return HttpResponse(res_json, content_type='application/json')
 
+    @list_route(methods=['GET',], detail=True)
+    def occurrence_threats(self, request, *args, **kwargs):
+        try:
+            instance = self.get_object()
+            occurrences = Occurrence.objects.filter(species=instance).values_list('id',flat=True)
+            threats = OCCConservationThreat.objects.filter(occurrence_id__in=occurrences)
+            serializer = OCCConservationThreatSerializer(threats, many=True, context={"request": request})
+            return Response(serializer.data)
+        except serializers.ValidationError:
+            print(traceback.print_exc())
+            raise
+        except ValidationError as e:
+            print(traceback.print_exc())
+            raise serializers.ValidationError(repr(e.error_dict))
+        except Exception as e:
+            print(traceback.print_exc())
+            raise serializers.ValidationError(str(e))
+    
     # used for species field on community profile
     # not used at the moment as per requirements
     # @detail_route(methods=['GET',], detail=False)
@@ -1584,6 +1604,23 @@ class CommunityViewSet(viewsets.ModelViewSet):
         res_json = json.dumps(related_type) 
         return HttpResponse(res_json, content_type='application/json')
 
+    @list_route(methods=['GET',], detail=True)
+    def occurrence_threats(self, request, *args, **kwargs):
+        try:
+            instance = self.get_object()
+            occurrences = Occurrence.objects.filter(community=instance).values_list('id',flat=True)
+            threats = OCCConservationThreat.objects.filter(occurrence_id__in=occurrences)
+            serializer = OCCConservationThreatSerializer(threats, many=True, context={"request": request})
+            return Response(serializer.data)
+        except serializers.ValidationError:
+            print(traceback.print_exc())
+            raise
+        except ValidationError as e:
+            print(traceback.print_exc())
+            raise serializers.ValidationError(repr(e.error_dict))
+        except Exception as e:
+            print(traceback.print_exc())
+            raise serializers.ValidationError(str(e))
 
     @detail_route(methods=['post'], detail=True)
     @renderer_classes((JSONRenderer,))

--- a/boranga/frontend/boranga/src/components/common/occurrence/occ_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occ_threats.vue
@@ -119,10 +119,10 @@ export default {
                             searchable: true,
                             mRender: function(data,type,full){
                                 if(full.visible){
-                                    return full.threat_number;
+                                    return "OCC" + full.occurrence + " - " + full.threat_number;
                                 }
                                 else{
-                                    return '<s>'+ full.threat_number + '</s>'
+                                    return '<s>'+ "OCC" + full.occurrence + " - " + full.threat_number + '</s>'
                                 }
                             },
 
@@ -132,11 +132,11 @@ export default {
                             orderable: true,
                             searchable: true,
                             mRender: function(data,type,full){
-                                if(full.visible){
-                                    return full.original_report;
+                                if(full.visible && full.original_report != null){
+                                    return full.original_report + " - " + full.original_threat;
                                 }
                                 else{
-                                    return '<s>'+ full.original_report + '</s>'
+                                    return ""
                                 }
                             },
 

--- a/boranga/frontend/boranga/src/components/common/occurrence/ocr_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/ocr_threats.vue
@@ -109,10 +109,10 @@ export default {
                             searchable: true,
                             mRender: function(data,type,full){
                                 if(full.visible){
-                                    return full.threat_number;
+                                    return "OCR" + full.occurrence_report.id + " - " + full.threat_number;
                                 }
                                 else{
-                                    return '<s>'+ full.threat_number + '</s>'
+                                    return '<s>'+ "OCR" + full.occurrence_report.id + " - " + full.threat_number + '</s>'
                                 }
                             },
 

--- a/boranga/frontend/boranga/src/components/common/species_communities/community_occ_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/community_occ_threats.vue
@@ -1,33 +1,16 @@
 <template lang="html">
-    <div id="community_threats">
-        <FormSection :formCollapse="false" label="Threats" Index="threats">
-            <form class="form-horizontal" action="index.html" method="post">
-                <div class="col-sm-12">
-                    <div class="text-end">
-                        <button type="button" class="btn btn-primary mb-2 " @click.prevent="newThreat">
-                            <i class="fa-solid fa-circle-plus"></i>
-                                Add Threat
-                        </button>
-                    </div>
-                </div>
-                <div>
-                    <datatable ref="threats_datatable" :id="panelBody" :dtOptions="threats_options"
-                    :dtHeaders="threats_headers"/>
-                </div>
-            </form>
-        </FormSection>
-        <FormSection :formCollapse="false" label="Occurrence Threats" :Index="occThreatBody">
-            <CommunityOCCThreats
-            :community_obj="species_community"
-            />
-        </FormSection>
+    <div id="community_occ_threats">
+        <div>
+            <datatable ref="threats_datatable" :id="panelBody" :dtOptions="threats_options"
+            :dtHeaders="threats_headers"/>
+        </div>
 
-        <ThreatDetail ref="threat_detail" @refreshFromResponse="refreshFromResponse" :url="threat_url"></ThreatDetail>
-        <div v-if="conservationThreatHistoryId">
+        <ThreatDetail ref="threat_detail" @refreshFromResponse="refreshFromResponse" :url="occ_threat_url"></ThreatDetail>
+        <div v-if="occConservationThreatHistoryId">
             <ConservationThreatHistory
-                ref="conservation_threat_history"
-                :key="conservationThreatHistoryId"
-                :threat-id="conservationThreatHistoryId"
+                ref="occ_conservation_threat_history"
+                :key="occConservationThreatHistoryId"
+                :threat-id="occConservationThreatHistoryId"
             />
         </div>
     </div>
@@ -35,11 +18,8 @@
 <script>
 import Vue from 'vue'
 import datatable from '@vue-utils/datatable.vue';
-import ThreatDetail from './add_threat.vue'
-import FormSection from '@/components/forms/section_toggle.vue';
-import ConservationThreatHistory from '../../internal/species_communities/conservation_threat_history.vue';
-import CommunityOCCThreats from '@/components/common/species_communities/community_occ_threats.vue';
-
+import ThreatDetail from '@/components/common/species_communities/add_threat.vue'
+import ConservationThreatHistory from '../../internal/occurrence/occ_conservation_threat_history.vue';
 import {
     constants,
     api_endpoints,
@@ -49,9 +29,9 @@ from '@/utils/hooks'
 
 
 export default {
-        name: 'CommunityThreats',
+        name: 'OCCThreats',
         props:{
-            species_community:{
+            community_obj:{
                 type: Object,
                 required:true
             },
@@ -60,12 +40,13 @@ export default {
             let vm = this;
             return{
                 uuid:0,
-                conservationThreatHistoryId: null,
-                panelBody: "community-threats-"+vm._uid,
+                occConservationThreatHistoryId: null,
+                showExisting: false,
+                threatBody: "threatBody"+ vm._uid,
+                panelBody: "community-threats-"+ vm._uid,
                 values:null,
-                occThreatBody: "occThreatBody"+ vm._uid,
-                threat_url: api_endpoints.threat,
-                threats_headers:['Number','Category', 'Threat Source', 'Date Observed', 'Threat Agent', 'Comments',
+                occ_threat_url: api_endpoints.occ_threat,
+                threats_headers:['Number', 'Original Report','Category', 'Threat Source', 'Date Observed', 'Threat Agent', 'Comments',
                                 'Current Impact', 'Potential Impact','Action'],
                 threats_options:{
                     autowidth: false,
@@ -80,7 +61,7 @@ export default {
                         { responsivePriority: 2, targets: -1 },
                     ],
                     ajax:{
-                        "url": helpers.add_endpoint_json(api_endpoints.community,vm.species_community.id+'/threats'),
+                        "url": helpers.add_endpoint_json(api_endpoints.community,vm.community_obj.id+'/occurrence_threats'),
                         "dataSrc": ''
                     },
                     order: [],
@@ -112,10 +93,24 @@ export default {
                             searchable: true,
                             mRender: function(data,type,full){
                                 if(full.visible){
-                                    return "C" + full.community + " - " + full.threat_number;
+                                    return "OCC" + full.occurrence + " - " + full.threat_number;
                                 }
                                 else{
-                                    return '<s>C' + full.community + " - " + full.threat_number + '</s>'
+                                    return '<s>'+ "OCC" + full.occurrence + " - " + full.threat_number + '</s>'
+                                }
+                            },
+
+                        },
+                        {
+                            data: "original_report",
+                            orderable: true,
+                            searchable: true,
+                            mRender: function(data,type,full){
+                                if(full.visible && full.original_report != null){
+                                    return full.original_report + " - " + full.original_threat;
+                                }
+                                else{
+                                    return ""
                                 }
                             },
 
@@ -220,12 +215,9 @@ export default {
                                 let links = '';
                                 if(full.visible){
                                     links +=  `<a href='#${full.id}' data-view-threat='${full.id}'>View</a><br/>`;
-                                    links +=  `<a href='#${full.id}' data-edit-threat='${full.id}'>Edit</a><br/>`;
-                                    links += `<a href='#' data-discard-threat='${full.id}'>Remove</a><br>`;
                                     links += `<a href='#' data-history-threat='${full.id}'>History</a><br>`;
                                 }
                                 else{
-                                    links += `<a href='#' data-reinstate-threat='${full.id}'>Reinstate</a><br>`;
                                     links += `<a href='#' data-history-threat='${full.id}'>History</a><br>`;
                                 }
                                 return links;
@@ -235,8 +227,8 @@ export default {
                     processing:true,
                     initComplete: function() {
                         helpers.enablePopovers();
-                        // to fix the responsive table overflow css on tab switch
-                        // vm.$refs.documents_datatable.vmDataTable.draw('page');
+                        // another option to fix the responsive table overflow css on tab switch
+                        // vm.$refs.threats_datatable.vmDataTable.draw('page');
                         setTimeout(function (){
                             vm.adjust_table_width();
                         },100);
@@ -245,55 +237,16 @@ export default {
             }
         },
         components: {
-            FormSection,
             datatable,
             ThreatDetail,
             ConservationThreatHistory,
-            CommunityOCCThreats,
-        },
-        computed: {
-        },
-        watch:{
-
         },
         methods:{
-            newThreat: function(){
-                let vm=this;
-                this.$refs.threat_detail.threat_id = '';
-                //-----for adding new community threat
-                var new_community_threat_another={
-                    community: vm.species_community.id,
-                    source:  vm.species_community.id,
-                    threat_category: '',
-                    threat_agent: '',
-                    comment: '',
-                    current_impact: '',
-                    potential_impact: '',
-                    potential_threat_onset: '',
-                    date_observed: null,
-                }
-                this.$refs.threat_detail.threatObj=new_community_threat_another;
-                this.$refs.threat_detail.threat_action='add';
-                this.$refs.threat_detail.isModalOpen = true;
-            },
-            editThreat: function(id){
-                let vm=this;
-                this.$refs.threat_detail.threat_id = id;
-                this.$refs.threat_detail.threat_action='edit';
-                Vue.http.get(helpers.add_endpoint_json(api_endpoints.threat,id)).then((response) => {
-                      this.$refs.threat_detail.threatObj=response.body;
-                      this.$refs.threat_detail.threatObj.date_observed =  response.body.date_observed != null && response.body.date_observed != undefined ? moment(response.body.date_observed).format('yyyy-MM-DD'): '';
-                    },
-                  err => {
-                            console.log(err);
-                      });
-                this.$refs.threat_detail.isModalOpen = true;
-            },
             viewThreat: function(id){
                 let vm=this;
                 this.$refs.threat_detail.threat_id = id;
                 this.$refs.threat_detail.threat_action='view';
-                Vue.http.get(helpers.add_endpoint_json(api_endpoints.threat,id)).then((response) => {
+                Vue.http.get(helpers.add_endpoint_json(api_endpoints.occ_threat,id)).then((response) => {
                       this.$refs.threat_detail.threatObj=response.body;
                       this.$refs.threat_detail.threatObj.date_observed =  response.body.date_observed != null && response.body.date_observed != undefined ? moment(response.body.date_observed).format('yyyy-MM-DD'): '';
                     },
@@ -303,66 +256,10 @@ export default {
                 this.$refs.threat_detail.isModalOpen = true;
             },
             historyThreat: function(id){
-                this.conservationThreatHistoryId = parseInt(id);
+                this.occConservationThreatHistoryId = parseInt(id);
                 this.uuid++;
                 this.$nextTick(() => {
-                    this.$refs.conservation_threat_history.isModalOpen = true;
-                });
-            },
-            discardThreat:function (id) {
-                let vm = this;
-                swal.fire({
-                    title: "Remove Threat",
-                    text: "Are you sure you want to remove this Threat?",
-                    icon: "warning",
-                    showCancelButton: true,
-                    confirmButtonText: 'Remove Threat',
-                    confirmButtonColor:'#d9534f'
-                }).then((result) => {
-                    if(result.isConfirmed){
-                        vm.$http.get(helpers.add_endpoint_json(api_endpoints.threat,id+'/discard'))
-                        .then((response) => {
-                            swal.fire({
-                                title: 'Discarded',
-                                text: 'Your threat has been removed',
-                                icon: 'success',
-                                confirmButtonColor:'#226fbb',
-                            });
-                            vm.$refs.threats_datatable.vmDataTable.ajax.reload();
-                        }, (error) => {
-                            console.log(error);
-                        });
-                    }
-                },(error) => {
-
-                });
-            },
-            reinstateThreat:function (id) {
-                let vm = this;
-                swal.fire({
-                    title: "Reinstate Threat",
-                    text: "Are you sure you want to Reinstate this Threat?",
-                    icon: "question",
-                    showCancelButton: true,
-                    confirmButtonText: 'Reinstate Threat',
-                    confirmButtonColor:'#226fbb',
-                }).then((result) => {
-                    if(result.isConfirmed){
-                        vm.$http.get(helpers.add_endpoint_json(api_endpoints.threat,id+'/reinstate'))
-                        .then((response) => {
-                            swal.fire({
-                                title: 'Reinstated',
-                                text: 'Your threat has been reinstated',
-                                icon: 'success',
-                                confirmButtonColor:'#226fbb',
-                            });
-                            vm.$refs.threats_datatable.vmDataTable.ajax.reload();
-                        }, (error) => {
-                            console.log(error);
-                        });
-                    }
-                },(error) => {
-
+                    this.$refs.occ_conservation_threat_history.isModalOpen = true;
                 });
             },
             updatedThreats(){
@@ -370,11 +267,6 @@ export default {
             },
             addEventListeners:function (){
                 let vm=this;
-                vm.$refs.threats_datatable.vmDataTable.on('click', 'a[data-edit-threat]', function(e) {
-                    e.preventDefault();
-                    var id = $(this).attr('data-edit-threat');
-                    vm.editThreat(id);
-                });
                 vm.$refs.threats_datatable.vmDataTable.on('click', 'a[data-view-threat]', function(e) {
                     e.preventDefault();
                     var id = $(this).attr('data-view-threat');
@@ -384,18 +276,6 @@ export default {
                     e.preventDefault();
                     var id = $(this).attr('data-history-threat');
                     vm.historyThreat(id);
-                });
-                // External Discard listener
-                vm.$refs.threats_datatable.vmDataTable.on('click', 'a[data-discard-threat]', function(e) {
-                    e.preventDefault();
-                    var id = $(this).attr('data-discard-threat');
-                    vm.discardThreat(id);
-                });
-                // External Reinstate listener
-                vm.$refs.threats_datatable.vmDataTable.on('click', 'a[data-reinstate-threat]', function(e) {
-                    e.preventDefault();
-                    var id = $(this).attr('data-reinstate-threat');
-                    vm.reinstateThreat(id);
                 });
             },
             refreshFromResponse: function(){

--- a/boranga/frontend/boranga/src/components/common/species_communities/community_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/community_threats.vue
@@ -103,10 +103,10 @@ export default {
                             searchable: true,
                             mRender: function(data,type,full){
                                 if(full.visible){
-                                    return full.threat_number;
+                                    return "C" + full.community + " - " + full.threat_number;
                                 }
                                 else{
-                                    return '<s>'+ full.threat_number + '</s>'
+                                    return '<s>C' + full.community + " - " + full.threat_number + '</s>'
                                 }
                             },
 

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_threats.vue
@@ -109,10 +109,10 @@ export default {
                             searchable: true,
                             mRender: function(data,type,full){
                                 if(full.visible){
-                                    return full.threat_number;
+                                    return "S" + full.species + " - " + full.threat_number;
                                 }
                                 else{
-                                    return '<s>'+ full.threat_number + '</s>'
+                                    return '<s> S'+ full.species_number + " - " + full.threat_number + '</s>'
                                 }
                             },
 

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_threats.vue
@@ -16,6 +16,12 @@
                 </div>
             </form>
         </FormSection>
+        <FormSection :formCollapse="false" label="Occurrence Threats" :Index="occThreatBody">
+            <SpeciesOCCThreats
+            :species_obj="species_community"
+            />
+        </FormSection>
+
         <ThreatDetail ref="threat_detail" @refreshFromResponse="refreshFromResponse" :url="threat_url"></ThreatDetail>
         <div v-if="conservationThreatHistoryId">
             <ConservationThreatHistory
@@ -32,6 +38,8 @@ import datatable from '@vue-utils/datatable.vue';
 import ThreatDetail from './add_threat.vue'
 import FormSection from '@/components/forms/section_toggle.vue';
 import ConservationThreatHistory from '../../internal/species_communities/conservation_threat_history.vue';
+import SpeciesOCCThreats from '@/components/common/species_communities/species_occ_threats.vue';
+
 import {
     constants,
     api_endpoints,
@@ -59,6 +67,7 @@ export default {
                 uuid:0,
                 conservationThreatHistoryId: null,
                 threatBody: "threatBody"+ vm._uid,
+                occThreatBody: "occThreatBody"+ vm._uid,
                 panelBody: "species-threats-"+ vm._uid,
                 values:null,
                 threat_url: api_endpoints.threat,
@@ -246,6 +255,7 @@ export default {
             datatable,
             ThreatDetail,
             ConservationThreatHistory,
+            SpeciesOCCThreats,
         },
         computed: {
             isReadOnly: function(){


### PR DESCRIPTION
Threat Numbers (of all kinds) are now displayed with a prefix to the record they pertain to e.g. OCC1 - T1

OCC threats copied from an OCR threat have the original OCR lists with the threat number e.g. OCR1 - T1

A read only OCC threat table is now available for Species and Communities, located underneath their own threat table