### PR TITLE
OCR & OCC History Columns

### DIFF
--- a/boranga/components/occurrence/models.py
+++ b/boranga/components/occurrence/models.py
@@ -3381,4 +3381,4 @@ reversion.register(OccurrenceDocument)
 reversion.register(OCCConservationThreat)
 
 # Occurrence
-reversion.register(Occurrence, follow=["species", "community"])
+reversion.register(Occurrence, follow=["species", "community","occurrence_reports"])

--- a/boranga/frontend/boranga/src/components/common/species_communities/community_occ_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/community_occ_threats.vue
@@ -47,7 +47,7 @@ export default {
                 values:null,
                 occ_threat_url: api_endpoints.occ_threat,
                 threats_headers:['Number', 'Original Report','Category', 'Date Observed', 'Threat Agent', 'Comments',
-                                'Current Impact', 'Threat Source', 'Potential Impact','Action'],
+                                'Current Impact', 'Potential Impact', 'Threat Source','Action'],
                 threats_options:{
                     autowidth: false,
                     language:{
@@ -130,20 +130,6 @@ export default {
 
                         },
                         {
-                            data: "source",
-                            orderable: true,
-                            searchable: true,
-                            mRender: function(data,type,full){
-                                if(full.visible){
-                                    return full.source;
-                                }
-                                else{
-                                    return '<s>'+ full.source + '</s>'
-                                }
-                            },
-
-                        },
-                        {
                             data: "date_observed",
                             mRender:function (data,type,full){
                                 if(full.visible){
@@ -208,6 +194,20 @@ export default {
                                     return '<s>'+ full.potential_impact_name + '</s>'
                                 }
                             },
+                        },
+                        {
+                            data: "source",
+                            orderable: true,
+                            searchable: true,
+                            mRender: function(data,type,full){
+                                if(full.visible){
+                                    return full.source;
+                                }
+                                else{
+                                    return '<s>'+ full.source + '</s>'
+                                }
+                            },
+
                         },
                         {
                             data: "id",

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_occ_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_occ_threats.vue
@@ -47,7 +47,7 @@ export default {
                 values:null,
                 occ_threat_url: api_endpoints.occ_threat,
                 threats_headers:['Number', 'Original Report','Category', 'Date Observed', 'Threat Agent', 'Comments',
-                                'Current Impact', 'Threat Source', 'Potential Impact','Action'],
+                                'Current Impact', 'Potential Impact', 'Threat Source','Action'],
                 threats_options:{
                     autowidth: false,
                     language:{
@@ -130,20 +130,6 @@ export default {
 
                         },
                         {
-                            data: "source",
-                            orderable: true,
-                            searchable: true,
-                            mRender: function(data,type,full){
-                                if(full.visible){
-                                    return full.source;
-                                }
-                                else{
-                                    return '<s>'+ full.source + '</s>'
-                                }
-                            },
-
-                        },
-                        {
                             data: "date_observed",
                             mRender:function (data,type,full){
                                 if(full.visible){
@@ -208,6 +194,20 @@ export default {
                                     return '<s>'+ full.potential_impact_name + '</s>'
                                 }
                             },
+                        },
+                        {
+                            data: "source",
+                            orderable: true,
+                            searchable: true,
+                            mRender: function(data,type,full){
+                                if(full.visible){
+                                    return full.source;
+                                }
+                                else{
+                                    return '<s>'+ full.source + '</s>'
+                                }
+                            },
+
                         },
                         {
                             data: "id",

--- a/boranga/frontend/boranga/src/components/internal/occurrence/community_occurrence_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/community_occurrence_history.vue
@@ -87,7 +87,10 @@ export default {
                 'Date Modified',
                 'Modified By',
                 'Community Name',
-                'Previous Name',
+                'Number of Reports',
+                'Wild Status',
+                'Occurrence Source',
+                //'Previous Name',
                 'Status',
                 'Action',
             ];
@@ -226,7 +229,7 @@ export default {
                 name: 'community_name',
             };
         },
-        column_previous_name: function () {
+        /*column_previous_name: function () {
             return {
                 data: 'data.data.communitytaxonomy.fields.previous_name', 
                 defaultContent: '',
@@ -263,6 +266,60 @@ export default {
                 },
                 name: 'previous_name', //_name',
             };
+        },*/
+        column_num_reports: function () {
+            return {                
+                data: 'data.data.occurrencereport',
+                defaultContent: '',
+                orderable: false,
+                searchable: false, 
+                visible: true,
+                render: function (row, type, full) {
+                    if (full.data.occurrencereport === undefined) {
+                        return 0;
+                    } else {
+                        if (full.data.occurrencereport.fields === undefined) {
+                            return full.data.occurrencereport.length
+                        } else {
+                            return 1;
+                        }
+                    }
+                },
+                name: 'number_of_reports',
+            };
+        },
+        column_wild_status: function () {
+            return {
+                data: 'data.data.occurrence.fields.wild_status',
+                defaultContent: '',
+                orderable: true,
+                searchable: false, 
+                visible: true,
+                render: function (row, type, full) {
+                    if (full.data.occurrence.fields.wild_status) {
+                        return full.data.occurrence.fields.wild_status.name;
+                    }
+                    return "";
+                },
+                name: 'wild_status',
+            };
+        },
+        column_occ_source: function () {
+            return {
+                
+                data: 'data.data.occurrence.fields.occurrence_source',
+                defaultContent: '',
+                orderable: true,
+                searchable: false, 
+                visible: true,
+                render: function (row, type, full) {
+                    if (full.data.occurrence.fields.occurrence_source) {
+                        return full.data.occurrence.fields.occurrence_source.name;
+                    }
+                    return "";
+                },
+                name: 'occurrence_source',
+            };
         },
         column_processing_status: function () {
             return {
@@ -298,7 +355,10 @@ export default {
                 vm.column_revision_date,
                 vm.column_revision_user,
                 vm.column_community_name,
-                vm.column_previous_name,
+                //vm.column_previous_name,
+                vm.column_num_reports,
+                vm.column_wild_status,
+                vm.column_occ_source,
                 vm.column_processing_status,
                 vm.column_action,
             ];

--- a/boranga/frontend/boranga/src/components/internal/occurrence/community_occurrence_report_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/community_occurrence_report_history.vue
@@ -86,8 +86,9 @@ export default {
                 'Number',
                 'Date Modified',
                 'Modified By',
+                'Occurrence',
                 'Community Name',
-                'Previous Name',
+                //'Previous Name',
                 'Status',
                 'Action',
             ];
@@ -226,7 +227,7 @@ export default {
                 name: 'community_name',
             };
         },
-        column_previous_name: function () {
+        /*column_previous_name: function () {
             return {
                 data: 'data.data.communitytaxonomy.fields.previous_name', 
                 defaultContent: '',
@@ -263,6 +264,22 @@ export default {
                 },
                 name: 'previous_name', //_name',
             };
+        },*/
+        column_occurrence: function () {
+            return {
+                
+                data: 'data.data.occurrencereport.fields.occurrence',
+                defaultContent: '',
+                orderable: true,
+                searchable: false, 
+                visible: true,
+                render: function (row, type, full) {
+                    if (full.data.occurrencereport.fields.occurrence)
+                        return "OCC"+full.data.occurrencereport.fields.occurrence;
+                    return ""
+                },
+                name: 'occurrence',
+            };
         },
         column_processing_status: function () {
             return {
@@ -297,8 +314,9 @@ export default {
                 vm.column_sequence,
                 vm.column_revision_date,
                 vm.column_revision_user,
+                vm.column_occurrence,
                 vm.column_community_name,
-                vm.column_previous_name,
+                //vm.column_previous_name,
                 vm.column_processing_status,
                 vm.column_action,
             ];

--- a/boranga/frontend/boranga/src/components/internal/occurrence/species_occurrence_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/species_occurrence_history.vue
@@ -87,8 +87,11 @@ export default {
                 'Date Modified',
                 'Modified By',
                 'Scientific Name',
-                'Common Name',
-                'Previous Name',
+                'Number of Reports',
+                'Wild Status',
+                'Occurrence Source',         
+                //'Common Name',
+                //'Previous Name',
                 'Status',
                 'Action',
             ];
@@ -236,7 +239,7 @@ export default {
                 name: 'scientific_name', //_name',
             };
         },
-        column_non_current_name: function () {
+        /*column_non_current_name: function () {
             return {
                 data: 'data.data.taxonomy.fields.non_current_name', 
                 defaultContent: '',
@@ -314,6 +317,60 @@ export default {
                 },
                 name: 'vernacular_name', //_name',
             };
+        },*/
+        column_num_reports: function () {
+            return {                
+                data: 'data.data.occurrencereport',
+                defaultContent: '',
+                orderable: false,
+                searchable: false, 
+                visible: true,
+                render: function (row, type, full) {
+                    if (full.data.occurrencereport === undefined) {
+                        return 0;
+                    } else {
+                        if (full.data.occurrencereport.fields === undefined) {
+                            return full.data.occurrencereport.length
+                        } else {
+                            return 1;
+                        }
+                    }
+                },
+                name: 'number_of_reports',
+            };
+        },
+        column_wild_status: function () {
+            return {
+                data: 'data.data.occurrence.fields.wild_status',
+                defaultContent: '',
+                orderable: true,
+                searchable: false, 
+                visible: true,
+                render: function (row, type, full) {
+                    if (full.data.occurrence.fields.wild_status) {
+                        return full.data.occurrence.fields.wild_status.name;
+                    }
+                    return "";
+                },
+                name: 'wild_status',
+            };
+        },
+        column_occ_source: function () {
+            return {
+                
+                data: 'data.data.occurrence.fields.occurrence_source',
+                defaultContent: '',
+                orderable: true,
+                searchable: false, 
+                visible: true,
+                render: function (row, type, full) {
+                    if (full.data.occurrence.fields.occurrence_source) {
+                        return full.data.occurrence.fields.occurrence_source.name;
+                    }
+                    return "";
+                },
+                name: 'occurrence_source',
+            };
         },
         column_processing_status: function () {
             return {
@@ -349,8 +406,11 @@ export default {
                 vm.column_revision_date,
                 vm.column_revision_user,
                 vm.column_scientific_name,
-                vm.column_common_name,
-                vm.column_non_current_name,
+                //vm.column_common_name,
+                //vm.column_non_current_name,
+                vm.column_num_reports,
+                vm.column_wild_status,
+                vm.column_occ_source,
                 vm.column_processing_status,
                 vm.column_action,
             ];

--- a/boranga/frontend/boranga/src/components/internal/occurrence/species_occurrence_report_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/species_occurrence_report_history.vue
@@ -86,9 +86,10 @@ export default {
                 'Number',
                 'Date Modified',
                 'Modified By',
+                'Occurrence',
                 'Scientific Name',
-                'Common Name',
-                'Previous Name',
+                //'Common Name',
+                //'Previous Name',
                 'Status',
                 'Action',
             ];
@@ -236,7 +237,7 @@ export default {
                 name: 'scientific_name', //_name',
             };
         },
-        column_non_current_name: function () {
+        /*column_non_current_name: function () {
             return {
                 data: 'data.data.taxonomy.fields.non_current_name', 
                 defaultContent: '',
@@ -314,6 +315,22 @@ export default {
                 },
                 name: 'vernacular_name', //_name',
             };
+        },*/
+        column_occurrence: function () {
+            return {
+                
+                data: 'data.data.occurrencereport.fields.occurrence',
+                defaultContent: '',
+                orderable: true,
+                searchable: false, 
+                visible: true,
+                render: function (row, type, full) {
+                    if (full.data.occurrencereport.fields.occurrence)
+                        return "OCC"+full.data.occurrencereport.fields.occurrence;
+                    return ""
+                },
+                name: 'occurrence',
+            };
         },
         column_processing_status: function () {
             return {
@@ -348,9 +365,10 @@ export default {
                 vm.column_sequence,
                 vm.column_revision_date,
                 vm.column_revision_user,
+                vm.column_occurrence,
                 vm.column_scientific_name,
-                vm.column_common_name,
-                vm.column_non_current_name,
+                //vm.column_common_name,
+                //vm.column_non_current_name,
                 vm.column_processing_status,
                 vm.column_action,
             ];


### PR DESCRIPTION
Adjusted OCC and OCR history columns to be more relevant to their respective records.

Removed previous name and common name values for OCC and OCR history (kept scientific/community names)

For OCC added number of reports (derived via number of related OCRs), wild status, and occurrence source.

For OCR added Occurrence (if OCR has been linked to one).

Some consideration made towards including OCR and OCC detail tables (habitat composition, observation details, etc) in reversion. Decide to hold off due to the large number of tables involved (18+ between both OCR and OCC, with revision versions compounded by OCC and OCR relations).