### PR TITLE
OCC Create, Lock, and Close

### DIFF
--- a/boranga/components/occurrence/api.py
+++ b/boranga/components/occurrence/api.py
@@ -2888,11 +2888,11 @@ class OccurrenceViewSet(UserActionLoggingViewset):
         ],
         detail=True,
     )
-    def lock_occurrence(self):
+    def lock_occurrence(self, request, *args, **kwargs):
         self.is_authorised_to_update()
         instance = self.get_object()
         instance.processing_status = Occurrence.PROCESSING_STATUS_LOCKED
-        instance.save(version_user=self.request.user)
+        instance.save(version_user=request.user)
         return redirect(reverse("internal"))
 
     @detail_route(
@@ -2901,8 +2901,8 @@ class OccurrenceViewSet(UserActionLoggingViewset):
         ],
         detail=True,
     )
-    def unlock_occurrence(self):
-        user = self.request.user
+    def unlock_occurrence(self, request, *args, **kwargs):
+        user = request.user
         instance = self.get_object()
         if not (user.id in instance.get_occurrence_editor_group().get_system_group_member_ids() and instance.processing_status == Occurrence.PROCESSING_STATUS_LOCKED):
             raise serializers.ValidationError("User not authorised to update Occurrence")
@@ -2916,11 +2916,11 @@ class OccurrenceViewSet(UserActionLoggingViewset):
         ],
         detail=True,
     )
-    def close_occurrence(self):
+    def close_occurrence(self, request, *args, **kwargs):
         self.is_authorised_to_update()
         instance = self.get_object()
         instance.processing_status = Occurrence.PROCESSING_STATUS_HISTORICAL
-        instance.save(version_user=self.request.user)
+        instance.save(version_user=request.user)
         return redirect(reverse("internal"))
     
     @detail_route(

--- a/boranga/components/occurrence/models.py
+++ b/boranga/components/occurrence/models.py
@@ -507,7 +507,7 @@ class OccurrenceReport(RevisionedMixin):
         if self.processing_status == OccurrenceReport.PROCESSING_STATUS_WITH_APPROVER:
             if officer.id != self.assigned_approver:
                 self.assigned_approver = officer.id
-                self.save()
+                self.save(version_user=request.user)
 
                 # Create a log entry for the proposal
                 self.log_user_action(
@@ -520,7 +520,7 @@ class OccurrenceReport(RevisionedMixin):
         else:
             if officer.id != self.assigned_officer:
                 self.assigned_officer = officer.id
-                self.save()
+                self.save(version_user=request.user)
 
                 # Create a log entry for the proposal
                 self.log_user_action(
@@ -538,7 +538,7 @@ class OccurrenceReport(RevisionedMixin):
         if self.processing_status == OccurrenceReport.PROCESSING_STATUS_WITH_APPROVER:
             if self.assigned_approver:
                 self.assigned_approver = None
-                self.save()
+                self.save(version_user=request.user)
 
                 # Create a log entry for the proposal
                 self.log_user_action(
@@ -550,7 +550,7 @@ class OccurrenceReport(RevisionedMixin):
         else:
             if self.assigned_officer:
                 self.assigned_officer = None
-                self.save()
+                self.save(version_user=request.user)
 
                 # Create a log entry for the proposal
                 self.log_user_action(
@@ -588,7 +588,7 @@ class OccurrenceReport(RevisionedMixin):
         self.approver_comment = ""
         OccurrenceReportApprovalDetails.objects.filter(occurrence_report=self).delete()
         self.processing_status = OccurrenceReport.PROCESSING_STATUS_WITH_APPROVER
-        self.save()
+        self.save(version_user=request.user)
 
         # Log proposal action
         self.log_user_action(
@@ -615,7 +615,7 @@ class OccurrenceReport(RevisionedMixin):
 
         self.processing_status = OccurrenceReport.PROCESSING_STATUS_DECLINED
         self.customer_status = OccurrenceReport.CUSTOMER_STATUS_DECLINED
-        self.save()
+        self.save(version_user=request.user)
 
         # Log proposal action
         self.log_user_action(
@@ -669,7 +669,7 @@ class OccurrenceReport(RevisionedMixin):
         self.proposed_decline_status = False
         OccurrenceReportDeclinedDetails.objects.filter(occurrence_report=self).delete()
         self.processing_status = OccurrenceReport.PROCESSING_STATUS_WITH_APPROVER
-        self.save()
+        self.save(version_user=request.user)
 
         # Log proposal action
         self.log_user_action(
@@ -709,10 +709,10 @@ class OccurrenceReport(RevisionedMixin):
                 )
             occurrence = Occurrence.clone_from_occurrence_report(self)
             occurrence.occurrence_name = self.approval_details.new_occurrence_name
-            occurrence.save()
+            occurrence.save(version_user=request.user)
 
         self.occurrence = occurrence
-        self.save()
+        self.save(version_user=request.user)
 
         # Log proposal action
         self.log_user_action(
@@ -735,7 +735,7 @@ class OccurrenceReport(RevisionedMixin):
             raise exceptions.OccurrenceReportNotAuthorized()
 
         self.processing_status = OccurrenceReport.PROCESSING_STATUS_WITH_ASSESSOR
-        self.save()
+        self.save(version_user=request.user)
 
         reason = validated_data.get("reason", "")
 
@@ -768,7 +768,7 @@ class OccurrenceReport(RevisionedMixin):
             == OccurrenceReport.PROCESSING_STATUS_WITH_REFERRAL
         ):
             self.processing_status = OccurrenceReport.PROCESSING_STATUS_WITH_REFERRAL
-            self.save()
+            self.save(version_user=request.user)
 
         referral = None
 
@@ -1019,7 +1019,7 @@ class OccurrenceReportAmendmentRequest(OccurrenceReportProposalRequest):
             if occurrence_report.processing_status != "draft":
                 occurrence_report.processing_status = "draft"
                 occurrence_report.customer_status = "draft"
-                occurrence_report.save()
+                occurrence_report.save(version_user=request.user)
 
             # Create a log entry for the occurrence report
             occurrence_report.log_user_action(
@@ -2753,7 +2753,7 @@ class Occurrence(RevisionedMixin):
         occurrence.reviewed_by = occurrence_report.reviewed_by
         occurrence.review_status = occurrence_report.review_status
 
-        occurrence.save()
+        occurrence.save(no_revision=True)
 
         # Clone all the associated models
         habitat_composition = clone_model(

--- a/boranga/components/occurrence/serializers.py
+++ b/boranga/components/occurrence/serializers.py
@@ -60,7 +60,7 @@ logger = logging.getLogger("boranga")
 
 
 class OccurrenceSerializer(serializers.ModelSerializer):
-    processing_status_display = serializers.CharField(
+    processing_status = serializers.CharField(
         source="get_processing_status_display"
     )
     scientific_name = serializers.CharField(
@@ -85,6 +85,9 @@ class OccurrenceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Occurrence
         fields = "__all__"
+
+    def get_processing_status(self, obj):
+        return obj.get_processing_status_display()
 
     def get_can_user_edit(self, obj):
         request = self.context["request"]
@@ -688,6 +691,10 @@ class OccurrenceLogEntrySerializer(CommunicationLogEntrySerializer):
 
 
 class ListOccurrenceSerializer(OccurrenceSerializer):
+    processing_status = serializers.CharField()
+    processing_status_display = serializers.CharField(
+        source="get_processing_status_display"
+    )
     effective_from = serializers.DateTimeField(
         format="%Y-%m-%d %H:%M:%S", allow_null=True
     )

--- a/boranga/frontend/boranga/src/components/common/occurrence_community_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_community_dashboard.vue
@@ -136,12 +136,9 @@ export default {
             // external_status refers to CUSTOMER_STATUS_CHOICES
             // internal_status referes to PROCESSING_STATUS_CHOICES
             internal_status:[
-                {value: 'draft', name: 'Draft'},
-                {value: 'with_assessor', name: 'With Assessor'},
-                {value: 'with_referral', name: 'With Referral'},
-                {value: 'with_approver', name: 'With Approver'},
-                {value: 'approved', name: 'Approved'},
-                {value: 'declined', name: 'Declined'},
+                {value: 'active', name: 'Active'},
+                {value: 'locked', name: 'Locked'},
+                {value: 'historical', name: 'Historical'},
             ],
 
             proposal_status: [],
@@ -498,17 +495,17 @@ export default {
             //large FilterList of Community Values object
 
             //TODO occurrence status filters...
-            
+
             vm.$http.get(api_endpoints.community_filter_dict+ '?group_type_name=' + vm.group_type_name).then((response) => {
                 vm.filterListsCommunity = response.body;
                 vm.occurrence_list = vm.filterListsCommunity.occurrence_list;
                 vm.community_name_list = vm.filterListsCommunity.community_name_list;
-                //vm.status_list = vm.filterListsCommunity.status_list;
+                vm.status_list = vm.filterListsCommunity.status_list;
                 vm.submissions_from_list = vm.filterListsCommunity.submissions_from_list;
                 vm.submissions_to_list = vm.filterListsCommunity.submissions_to_list;
-                //vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
-                //        return a.name.trim().localeCompare(b.name.trim());
-                //    });
+                vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
+                        return a.name.trim().localeCompare(b.name.trim());
+                    });
                 //vm.proposal_status = vm.level == 'internal' ? response.body.processing_status_choices: response.body.customer_status_choices;
                 //vm.proposal_status = vm.level == 'internal' ? vm.internal_status: vm.external_status;
             },(error) => {

--- a/boranga/frontend/boranga/src/components/common/occurrence_community_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_community_dashboard.vue
@@ -32,6 +32,12 @@
             </div>
         </CollapsibleFilters>
 
+        <div class="col-md-12">
+            <div class="text-end">
+                <button type="button" class="btn btn-primary mb-2 " @click.prevent="createCommunityOccurrence"><i class="fa-solid fa-circle-plus"></i> Add Community Occurrence</button>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col-lg-12">
                 <datatable
@@ -512,11 +518,12 @@ export default {
                 console.log(error);
             })
         },
-        createCommunityOccurrenceReport: async function () {
+        createCommunityOccurrence: async function () {
             let newCommunityOCCId = null
             try {
-                    const createUrl = api_endpoints.occurrence+"/";
+                    const createUrl = api_endpoints.occurrence;
                     let payload = new Object();
+                    payload.group_type_id = this.group_type_id
                     payload.internal_application = true
                     let savedCommunityOCC = await Vue.http.post(createUrl, payload);
                     if (savedCommunityOCC) {

--- a/boranga/frontend/boranga/src/components/common/occurrence_community_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_community_dashboard.vue
@@ -496,16 +496,19 @@ export default {
         fetchFilterLists: function(){
             let vm = this;
             //large FilterList of Community Values object
+
+            //TODO occurrence status filters...
+            
             vm.$http.get(api_endpoints.community_filter_dict+ '?group_type_name=' + vm.group_type_name).then((response) => {
                 vm.filterListsCommunity = response.body;
                 vm.occurrence_list = vm.filterListsCommunity.occurrence_list;
                 vm.community_name_list = vm.filterListsCommunity.community_name_list;
-                vm.status_list = vm.filterListsCommunity.status_list;
+                //vm.status_list = vm.filterListsCommunity.status_list;
                 vm.submissions_from_list = vm.filterListsCommunity.submissions_from_list;
                 vm.submissions_to_list = vm.filterListsCommunity.submissions_to_list;
-                vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
-                        return a.name.trim().localeCompare(b.name.trim());
-                    });
+                //vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
+                //        return a.name.trim().localeCompare(b.name.trim());
+                //    });
                 //vm.proposal_status = vm.level == 'internal' ? response.body.processing_status_choices: response.body.customer_status_choices;
                 //vm.proposal_status = vm.level == 'internal' ? vm.internal_status: vm.external_status;
             },(error) => {

--- a/boranga/frontend/boranga/src/components/common/occurrence_fauna_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_fauna_dashboard.vue
@@ -30,6 +30,13 @@
                 </div>
             </div>
         </CollapsibleFilters>
+
+        <div class="col-md-12">
+            <div class="text-end">
+                <button type="button" class="btn btn-primary mb-2 " @click.prevent="createFaunaOccurrence"><i class="fa-solid fa-circle-plus"></i> Add Fauna Occurrence</button>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col-lg-12">
                 <datatable ref="fauna_occ_datatable" :id="datatable_id" :dtOptions="datatable_options"
@@ -493,7 +500,7 @@ export default {
         createFaunaOccurrence: async function () {
             let newFaunaOCRId = null
             try {
-                const createUrl = api_endpoints.occurrence + "/";
+                const createUrl = api_endpoints.occurrence;
                 let payload = new Object();
                 payload.group_type_id = this.group_type_id
                 payload.internal_application = true
@@ -509,7 +516,7 @@ export default {
                 }
             }
             this.$router.push({
-                name: 'internal-occurrence',
+                name: 'internal-occurrence-detail',
                 params: { occurrence_id: newFaunaOCRId },
             });
         },

--- a/boranga/frontend/boranga/src/components/common/occurrence_fauna_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_fauna_dashboard.vue
@@ -133,12 +133,10 @@ export default {
             submissions_to_list: [],
 
             // filtering options
-            internal_status: [
-                { value: 'draft', name: 'Draft' },
-                { value: 'locked', name: 'Locked' },
-                { value: 'split', name: 'Split' },
-                { value: 'combine', name: 'Combine' },
-                { value: 'historical', name: 'Historical' },
+            internal_status:[
+                {value: 'active', name: 'Active'},
+                {value: 'locked', name: 'Locked'},
+                {value: 'historical', name: 'Historical'},
             ],
 
             proposal_status: [],
@@ -480,14 +478,14 @@ export default {
                 vm.filterListsSpecies = response.body;
                 vm.occurrence_list = vm.filterListsSpecies.occurrence_list;
                 vm.scientific_name_list = vm.filterListsSpecies.scientific_name_list;
-                //vm.status_list = vm.filterListsSpecies.status_list;
+                vm.status_list = vm.filterListsSpecies.status_list;
                 vm.submissions_from_list = vm.filterListsSpecies.submissions_from_list;
                 vm.submissions_to_list = vm.filterListsSpecies.submissions_to_list;
                 // vm.filterConservationCategory();
                 // vm.filterDistrict();
-                //vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
-                //    return a.name.trim().localeCompare(b.name.trim());
-                //});
+                vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
+                    return a.name.trim().localeCompare(b.name.trim());
+                });
             }, (error) => {
                 console.log(error);
             })

--- a/boranga/frontend/boranga/src/components/common/occurrence_fauna_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_fauna_dashboard.vue
@@ -473,18 +473,21 @@ export default {
         fetchFilterLists: function () {
             let vm = this;
             //large FilterList of Species Values object
+
+            //TODO occurrence status filters...
+
             vm.$http.get(api_endpoints.filter_lists_species + '?group_type_name=' + vm.group_type_name).then((response) => {
                 vm.filterListsSpecies = response.body;
                 vm.occurrence_list = vm.filterListsSpecies.occurrence_list;
                 vm.scientific_name_list = vm.filterListsSpecies.scientific_name_list;
-                vm.status_list = vm.filterListsSpecies.status_list;
+                //vm.status_list = vm.filterListsSpecies.status_list;
                 vm.submissions_from_list = vm.filterListsSpecies.submissions_from_list;
                 vm.submissions_to_list = vm.filterListsSpecies.submissions_to_list;
                 // vm.filterConservationCategory();
                 // vm.filterDistrict();
-                vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
-                    return a.name.trim().localeCompare(b.name.trim());
-                });
+                //vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
+                //    return a.name.trim().localeCompare(b.name.trim());
+                //});
             }, (error) => {
                 console.log(error);
             })

--- a/boranga/frontend/boranga/src/components/common/occurrence_flora_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_flora_dashboard.vue
@@ -133,12 +133,10 @@ export default {
             submissions_to_list: [],
 
             // filtering options
-            internal_status: [
-                { value: 'draft', name: 'Draft' },
-                { value: 'locked', name: 'Locked' },
-                { value: 'split', name: 'Split' },
-                { value: 'combine', name: 'Combine' },
-                { value: 'historical', name: 'Historical' },
+            internal_status:[
+                {value: 'active', name: 'Active'},
+                {value: 'locked', name: 'Locked'},
+                {value: 'historical', name: 'Historical'},
             ],
 
             proposal_status: [],
@@ -474,21 +472,18 @@ methods: {
     fetchFilterLists: function () {
         let vm = this;
         //large FilterList of Species Values object
-
-        //TODO occurrence status filters...
-
         vm.$http.get(api_endpoints.filter_lists_species + '?group_type_name=' + vm.group_type_name).then((response) => {
             vm.filterListsSpecies = response.body;
             vm.occurrence_list = vm.filterListsSpecies.occurrence_list;
             vm.scientific_name_list = vm.filterListsSpecies.scientific_name_list;
-            //vm.status_list = vm.filterListsSpecies.status_list;
+            vm.status_list = vm.filterListsSpecies.status_list;
             vm.submissions_from_list = vm.filterListsSpecies.submissions_from_list;
             vm.submissions_to_list = vm.filterListsSpecies.submissions_to_list;
             // vm.filterConservationCategory();
             // vm.filterDistrict();
-            //vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
-            //    return a.name.trim().localeCompare(b.name.trim());
-            //});
+            vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
+                return a.name.trim().localeCompare(b.name.trim());
+            });
         }, (error) => {
             console.log(error);
         })

--- a/boranga/frontend/boranga/src/components/common/occurrence_flora_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_flora_dashboard.vue
@@ -474,18 +474,21 @@ methods: {
     fetchFilterLists: function () {
         let vm = this;
         //large FilterList of Species Values object
+
+        //TODO occurrence status filters...
+
         vm.$http.get(api_endpoints.filter_lists_species + '?group_type_name=' + vm.group_type_name).then((response) => {
             vm.filterListsSpecies = response.body;
             vm.occurrence_list = vm.filterListsSpecies.occurrence_list;
             vm.scientific_name_list = vm.filterListsSpecies.scientific_name_list;
-            vm.status_list = vm.filterListsSpecies.status_list;
+            //vm.status_list = vm.filterListsSpecies.status_list;
             vm.submissions_from_list = vm.filterListsSpecies.submissions_from_list;
             vm.submissions_to_list = vm.filterListsSpecies.submissions_to_list;
             // vm.filterConservationCategory();
             // vm.filterDistrict();
-            vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
-                return a.name.trim().localeCompare(b.name.trim());
-            });
+            //vm.proposal_status = vm.internal_status.slice().sort((a, b) => {
+            //    return a.name.trim().localeCompare(b.name.trim());
+            //});
         }, (error) => {
             console.log(error);
         })

--- a/boranga/frontend/boranga/src/components/common/occurrence_flora_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_flora_dashboard.vue
@@ -30,6 +30,13 @@
                 </div>
             </div>
         </CollapsibleFilters>
+
+        <div class="col-md-12">
+            <div class="text-end">
+                <button type="button" class="btn btn-primary mb-2 " @click.prevent="createFloraOccurrence"><i class="fa-solid fa-circle-plus"></i> Add Flora Occurrence</button>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col-lg-12">
                 <datatable ref="flora_occ_datatable" :id="datatable_id" :dtOptions="datatable_options"
@@ -491,7 +498,7 @@ methods: {
     createFloraOccurrence: async function () {
         let newFloraOCRId = null
         try {
-            const createUrl = api_endpoints.occurrence + "/";
+            const createUrl = api_endpoints.occurrence;
             let payload = new Object();
             payload.group_type_id = this.group_type_id
             payload.internal_application = true
@@ -507,7 +514,7 @@ methods: {
             }
         }
         this.$router.push({
-            name: 'internal-occurrence',
+            name: 'internal-occurrence-detail',
             params: { occurrence_id: newFloraOCRId },
         });
     },

--- a/boranga/frontend/boranga/src/components/internal/occurrence/occurrence.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/occurrence.vue
@@ -35,17 +35,29 @@
                                                 </div>
                                             </div>
                                             <div class="row">
+                                                <div v-if="canLock" class="col-sm-12">
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
+                                                        @click.prevent="lockOccurrence()">Lock</button><br />
+                                                </div>
+                                                <div v-if="canUnlock" class="col-sm-12">
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
+                                                        @click.prevent="unlockOccurrence()">Unlock</button><br />
+                                                </div>
                                                 <div class="col-sm-12">
-                                                    <button style="width:80%;" class="btn btn-primary top-buffer-s"
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
                                                         @click.prevent="splitOccurrence()">Split</button><br />
                                                 </div>
                                                 <div class="col-sm-12">
-                                                    <button style="width:80%;" class="btn btn-primary top-buffer-s"
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
                                                         @click.prevent="combineOccurrence()">Combine</button><br />
                                                 </div>
                                                 <div class="col-sm-12">
-                                                    <button style="width:80%;" class="btn btn-primary top-buffer-s"
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
                                                         @click.prevent="renameOccurrence()">Rename</button><br />
+                                                </div>
+                                                <div v-if="canClose" class="col-sm-12">
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
+                                                        @click.prevent="closeOccurrence()">Close</button><br />
                                                 </div>
                                             </div>
                                         </template>
@@ -229,8 +241,15 @@ export default {
                 return false;
             }
         },
-        canDiscard: function () {
-            return this.occurrence && this.occurrence.processing_status === "Draft" ? true : false;
+        canLock: function () {
+            return this.occurrence && this.occurrence.processing_status === "Active" ? true : false;
+        },
+        canUnlock: function () {
+            return this.occurrence && this.occurrence.processing_status === "Locked" ? true : false;
+        },
+        //TODO: can we close locked? should we only close locked?
+        canClose: function () {
+            return this.occurrence && this.occurrence.processing_status === "Active" ? true : false;
         },
         comms_url: function () {
             return helpers.add_endpoint_json(api_endpoints.occurrence, this.$route.params.occurrence_id + '/comms_log')
@@ -405,6 +424,15 @@ export default {
             let vm = this;
             vm.original_occurrence = helpers.copyObject(response.body);
             vm.occurrence = helpers.copyObject(response.body);
+        },
+        lockOccurrence: async function () {
+
+        },
+        unlockOccurrence: async function () {
+
+        },
+        closeOccurrence: async function () {
+
         },
         splitOccurrence: async function () {
             this.$refs.occurrence_split.occurrence_original = this.occurrence;


### PR DESCRIPTION
Added functions for creating, locking, unlocking, and closing Occurrences.

 - Occurrences can now be created directly (without an OCR) via an Add Button on the available OCC dashboards. Members of the Occurrence approval group can create Occurrences.

 - Active Occurrences can now be locked. A locked Occurrence cannot have any changes made to it, except for unlocking. Once unlocked an Occurrence will become Active again.

 - Active Occurrences can now be closed. A closed Occurrence will have its status set to "Historical" and will no longer be modifiable.

Some other minor updates include:

 - Occurrence status filter now reflects the existing Occurrence statuses available
 - Some OCR/OCC history recordings did not have a user attributed to them, this has been fixed
 - The Save buttons on the Occurrence page will now save every detail similar to how it works on the OCR page