### PR TITLE
Save adjustment, create fix

### DIFF
--- a/boranga/components/conservation_status/models.py
+++ b/boranga/components/conservation_status/models.py
@@ -488,7 +488,8 @@ class ConservationStatus(RevisionedMixin):
 
     def save(self, *args, **kwargs):
         if self.conservation_status_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_conservation_status_id = f"CS{str(self.pk)}"
             self.conservation_status_number = new_conservation_status_id
             self.save(*args, **kwargs)
@@ -1546,7 +1547,8 @@ class ConservationStatusDocument(Document):
     def save(self, *args, **kwargs):
         # Prefix "D" char to document_number.
         if self.document_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_document_id = f"D{str(self.pk)}"
             self.document_number = new_document_id
             self.save(*args, **kwargs)

--- a/boranga/components/meetings/models.py
+++ b/boranga/components/meetings/models.py
@@ -358,7 +358,8 @@ class Minutes(Document):
     def save(self, *args, **kwargs):
         # Prefix "MN" char to minutes_number.
         if self.minutes_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_minute_id = f"MN{str(self.pk)}"
             self.minutes_number = new_minute_id
             self.save(*args, **kwargs)

--- a/boranga/components/occurrence/models.py
+++ b/boranga/components/occurrence/models.py
@@ -270,7 +270,8 @@ class OccurrenceReport(RevisionedMixin):
 
     def save(self, *args, **kwargs):
         if self.occurrence_report_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_occurrence_report_id = f"OCR{str(self.pk)}"
             self.occurrence_report_number = new_occurrence_report_id
             self.save(*args, **kwargs)
@@ -2392,7 +2393,8 @@ class OccurrenceReportDocument(Document):
     def save(self, *args, **kwargs):
         # Prefix "D" char to document_number.
         if self.document_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_document_id = f"D{str(self.pk)}"
             self.document_number = new_document_id
             self.save(*args, **kwargs)
@@ -2519,7 +2521,8 @@ class OCRConservationThreat(RevisionedMixin):
 
     def save(self, *args, **kwargs):
         if self.threat_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_threat_id = f"T{str(self.pk)}"
             self.threat_number = new_threat_id
             self.save(*args, **kwargs)
@@ -2651,7 +2654,8 @@ class Occurrence(RevisionedMixin):
 
     def save(self, *args, **kwargs):
         if self.occurrence_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             self.occurrence_number = f"OCC{str(self.pk)}"
             self.save(*args, **kwargs)
         else:
@@ -2943,7 +2947,8 @@ class OccurrenceDocument(Document):
     def save(self, *args, **kwargs):
         # Prefix "D" char to document_number.
         if self.document_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_document_id = f"D{str(self.pk)}"
             self.document_number = new_document_id
             self.save(*args, **kwargs)
@@ -3071,7 +3076,8 @@ class OCCConservationThreat(RevisionedMixin):
 
     def save(self, *args, **kwargs):
         if self.threat_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_threat_id = f"T{str(self.pk)}"
             self.threat_number = new_threat_id
             self.save(*args, **kwargs)

--- a/boranga/components/species_and_communities/models.py
+++ b/boranga/components/species_and_communities/models.py
@@ -540,7 +540,8 @@ class Species(RevisionedMixin):
         self.full_clean()
         # Prefix "S" char to species_number.
         if self.species_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_species_id = f"S{str(self.pk)}"
             self.species_number = new_species_id
             self.save(*args, **kwargs)
@@ -1170,7 +1171,8 @@ class Community(RevisionedMixin):
     def save(self, *args, **kwargs):
         # Prefix "C" char to community_number.
         if self.community_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_community_id = f"C{str(self.pk)}"
             self.community_number = new_community_id
             self.save(*args, **kwargs)
@@ -1772,7 +1774,8 @@ class SpeciesDocument(Document):
     def save(self, *args, **kwargs):
         # Prefix "D" char to document_number.
         if self.document_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_document_id = f"D{str(self.pk)}"
             self.document_number = new_document_id
             self.save(*args, **kwargs)
@@ -1868,7 +1871,8 @@ class CommunityDocument(Document):
     def save(self, *args, **kwargs):
         # Prefix "D" char to document_number.
         if self.document_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_document_id = f"D{str(self.pk)}"
             self.document_number = new_document_id
             self.save(*args, **kwargs)
@@ -2051,7 +2055,8 @@ class ConservationThreat(RevisionedMixin):
 
     def save(self, *args, **kwargs):
         if self.threat_number == "":
-            super().save(no_revision=True)
+            force_insert = kwargs.pop('force_insert', False)
+            super().save(no_revision=True, force_insert=force_insert)
             new_threat_id = f"T{str(self.pk)}"
             self.threat_number = new_threat_id
             self.save(*args, **kwargs)


### PR DESCRIPTION
To accommodate key word arguments necessary for reversion and to record model instance "numbers" in each initial revision instance, the save function of a number of models were altered. 

When one of these models are saved, they are first saved with the "no_revision" keyword argument to initialise the record without saving a revision instance. The record number of the instance is then generated, and then the instance is saved again, this time with the revision creation allowed.

The problem was that is the model instance was created using the create() function, it would send through a "force_insert" keyword argument, which due to how the instance was initialised and updated would cause the second save to trigger a duplication error - the force insert would attempt to create a new record with the same PK.

While this does not affect the functionality of the models, as none of them generate records using create(), this PR still addresses this issue so that the function can be used - in case it is required for debugging or later functionality.

This PR fixes the issue by forcing any force insert keyword argument to run on the initial save for the affected models, and not the second. This has been tested - the create() function now works for all affected models and existing functionality has not changed.