### PR TITLE
Date range filters

### DIFF
--- a/boranga/components/conservation_status/api.py
+++ b/boranga/components/conservation_status/api.py
@@ -352,28 +352,49 @@ class SpeciesConservationStatusFilterBackend(DatatablesFilterBackend):
                     conservation_status__species__district=filter_district
                 )
 
-        filter_effective_from_date = request.GET.get("filter_effective_from_date")
-        filter_effective_to_date = request.GET.get("filter_effective_to_date")
+        filter_from_effective_from_date = request.GET.get("filter_from_effective_from_date")
+        filter_to_effective_from_date = request.GET.get("filter_to_effective_from_date")
+
+        filter_from_effective_to_date = request.GET.get("filter_from_effective_to_date")
+        filter_to_effective_to_date = request.GET.get("filter_to_effective_to_date")
+        
         if queryset.model is ConservationStatus:
-            if filter_effective_from_date:
+            if filter_from_effective_from_date:
                 queryset = queryset.filter(
-                    conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_effective_from_date
+                    conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_from_effective_from_date
+                )
+            if filter_to_effective_from_date:
+                queryset = queryset.filter(
+                    conservationstatusissuanceapprovaldetails__effective_from_date__lte=filter_to_effective_from_date
                 )
 
-            if filter_effective_to_date:
+            if filter_from_effective_to_date:
                 queryset = queryset.filter(
-                    conservationstatusissuanceapprovaldetails__effective_to_date__lte=filter_effective_to_date
+                    conservationstatusissuanceapprovaldetails__effective_to_date__gte=filter_from_effective_to_date
+                )
+            if filter_to_effective_to_date:
+                queryset = queryset.filter(
+                    conservationstatusissuanceapprovaldetails__effective_to_date__lte=filter_to_effective_to_date
                 )
 
         elif queryset.model is ConservationStatusReferral:
-            if filter_effective_from_date:
+
+            if filter_from_effective_from_date:
                 queryset = queryset.filter(
-                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_effective_from_date  # noqa
+                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_from_effective_from_date #noqa
+                )
+            if filter_to_effective_from_date:
+                queryset = queryset.filter(
+                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__lte=filter_to_effective_from_date #noqa
                 )
 
-            if filter_effective_to_date:
+            if filter_from_effective_to_date:
                 queryset = queryset.filter(
-                    conservation_status__conservationstatusissuanceapprovaldetails__effective_to_date__lte=filter_effective_to_date  # noqa
+                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_from_effective_to_date #noqa
+                )
+            if filter_to_effective_to_date:
+                queryset = queryset.filter(
+                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__lte=filter_to_effective_to_date #noqa
                 )
 
         filter_application_status = request.GET.get("filter_application_status")
@@ -804,28 +825,48 @@ class CommunityConservationStatusFilterBackend(DatatablesFilterBackend):
                     conservation_status__community__district=filter_district
                 )
 
-        filter_effective_from_date = request.GET.get("filter_effective_from_date")
-        filter_effective_to_date = request.GET.get("filter_effective_to_date")
+        filter_from_effective_from_date = request.GET.get("filter_from_effective_from_date")
+        filter_to_effective_from_date = request.GET.get("filter_to_effective_from_date")
+
+        filter_from_effective_to_date = request.GET.get("filter_from_effective_to_date")
+        filter_to_effective_to_date = request.GET.get("filter_to_effective_to_date")
         if queryset.model is ConservationStatus:
-            if filter_effective_from_date:
+            if filter_from_effective_from_date:
                 queryset = queryset.filter(
-                    conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_effective_from_date
+                    conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_from_effective_from_date
+                )
+            if filter_to_effective_from_date:
+                queryset = queryset.filter(
+                    conservationstatusissuanceapprovaldetails__effective_from_date__lte=filter_to_effective_from_date
                 )
 
-            if filter_effective_to_date:
+            if filter_from_effective_to_date:
                 queryset = queryset.filter(
-                    conservationstatusissuanceapprovaldetails__effective_to_date__lte=filter_effective_to_date
+                    conservationstatusissuanceapprovaldetails__effective_to_date__gte=filter_from_effective_to_date
+                )
+            if filter_to_effective_to_date:
+                queryset = queryset.filter(
+                    conservationstatusissuanceapprovaldetails__effective_to_date__lte=filter_to_effective_to_date
                 )
 
         elif queryset.model is ConservationStatusReferral:
-            if filter_effective_from_date:
+
+            if filter_from_effective_from_date:
                 queryset = queryset.filter(
-                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_effective_from_date  # noqa
+                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_from_effective_from_date #noqa
+                )
+            if filter_to_effective_from_date:
+                queryset = queryset.filter(
+                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__lte=filter_to_effective_from_date #noqa
                 )
 
-            if filter_effective_to_date:
+            if filter_from_effective_to_date:
                 queryset = queryset.filter(
-                    conservation_status__conservationstatusissuanceapprovaldetails__effective_to_date__lte=filter_effective_to_date  # noqa
+                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__gte=filter_from_effective_to_date #noqa
+                )
+            if filter_to_effective_to_date:
+                queryset = queryset.filter(
+                    conservation_status__conservationstatusissuanceapprovaldetails__effective_from_date__lte=filter_to_effective_to_date #noqa
                 )
 
         filter_application_status = request.GET.get("filter_application_status")

--- a/boranga/components/meetings/api.py
+++ b/boranga/components/meetings/api.py
@@ -59,14 +59,21 @@ class MeetingFilterBackend(DatatablesFilterBackend):
                 # changed to application_type (ie group_type)
                 queryset = queryset
 
-        filter_start_date = request.GET.get("filter_start_date")
-        filter_end_date = request.GET.get("filter_end_date")
+        filter_from_start_date = request.GET.get("filter_from_start_date")
+        filter_to_start_date = request.GET.get("filter_to_start_date")
+        print(filter_to_start_date)
+        filter_from_end_date = request.GET.get("filter_from_end_date")
+        filter_to_end_date = request.GET.get("filter_to_end_date")
         if queryset.model is Meeting:
-            if filter_start_date:
-                queryset = queryset.filter(start_date__gte=filter_start_date)
+            if filter_from_start_date:
+                queryset = queryset.filter(start_date__gte=filter_from_start_date)
+            if filter_to_start_date:
+                queryset = queryset.filter(start_date__lte=filter_to_start_date)
 
-            if filter_end_date:
-                queryset = queryset.filter(end_date__lte=filter_end_date)
+            if filter_from_end_date:
+                queryset = queryset.filter(end_date__gte=filter_from_end_date)
+            if filter_to_end_date:
+                queryset = queryset.filter(end_date__lte=filter_to_end_date)
 
         filter_meeting_status = request.GET.get("filter_meeting_status")
         if filter_meeting_status and not filter_meeting_status.lower() == "all":

--- a/boranga/components/occurrence/api.py
+++ b/boranga/components/occurrence/api.py
@@ -2286,6 +2286,42 @@ class OccurrenceFilterBackend(DatatablesFilterBackend):
         if filter_status and not filter_status.lower() == "all":
             queryset = queryset.filter(processing_status=filter_status)
 
+        filter_from_effective_from_date = request.GET.get("filter_from_effective_from_date")
+        filter_to_effective_from_date = request.GET.get("filter_to_effective_from_date")
+
+        filter_from_effective_to_date = request.GET.get("filter_from_effective_to_date")
+        filter_to_effective_to_date = request.GET.get("filter_to_effective_to_date")
+
+        if filter_from_effective_from_date:
+            queryset = queryset.filter(
+                effective_from__gte=filter_from_effective_from_date
+            )
+        if filter_to_effective_from_date:
+            queryset = queryset.filter(
+                effective_from__lte=filter_to_effective_from_date
+            )
+
+        if filter_from_effective_to_date:
+            queryset = queryset.filter(
+                effective_to__gte=filter_from_effective_to_date
+            )
+        if filter_to_effective_to_date:
+            queryset = queryset.filter(
+                effective_to__lte=filter_to_effective_to_date
+            )
+
+        filter_from_review_due_date = request.GET.get("filter_from_review_due_date")
+        filter_to_review_due_date = request.GET.get("filter_to_review_due_date")
+
+        if filter_from_review_due_date:
+            queryset = queryset.filter(
+                review_due_date__gte=filter_from_review_due_date
+            )
+        if filter_to_review_due_date:
+            queryset = queryset.filter(
+                review_due_date__lte=filter_to_review_due_date
+            )
+
         fields = self.get_fields(request)
 
         ordering = self.get_ordering(request, view, fields)

--- a/boranga/components/occurrence/api.py
+++ b/boranga/components/occurrence/api.py
@@ -212,6 +212,43 @@ class OccurrenceReportFilterBackend(DatatablesFilterBackend):
             if filter_submitted_to_date and not filter_submitted_from_date:
                 queryset = queryset.filter(reported_date__lte=filter_submitted_to_date)
 
+
+            filter_from_effective_from_date = request.GET.get("filter_from_effective_from_date")
+            filter_to_effective_from_date = request.GET.get("filter_to_effective_from_date")
+
+            filter_from_effective_to_date = request.GET.get("filter_from_effective_to_date")
+            filter_to_effective_to_date = request.GET.get("filter_to_effective_to_date")
+
+            if filter_from_effective_from_date:
+                queryset = queryset.filter(
+                    effective_from__gte=filter_from_effective_from_date
+                )
+            if filter_to_effective_from_date:
+                queryset = queryset.filter(
+                    effective_from__lte=filter_to_effective_from_date
+                )
+
+            if filter_from_effective_to_date:
+                queryset = queryset.filter(
+                    effective_to__gte=filter_from_effective_to_date
+                )
+            if filter_to_effective_to_date:
+                queryset = queryset.filter(
+                    effective_to__lte=filter_to_effective_to_date
+                )
+
+            filter_from_review_due_date = request.GET.get("filter_from_review_due_date")
+            filter_to_review_due_date = request.GET.get("filter_to_review_due_date")
+
+            if filter_from_review_due_date:
+                queryset = queryset.filter(
+                    review_due_date__gte=filter_from_review_due_date
+                )
+            if filter_to_review_due_date:
+                queryset = queryset.filter(
+                    review_due_date__lte=filter_to_review_due_date
+                )
+
         if "external" in view.name:
             total_count = queryset.count()
 

--- a/boranga/components/occurrence/serializers.py
+++ b/boranga/components/occurrence/serializers.py
@@ -1666,7 +1666,7 @@ class OCRConservationThreatSerializer(serializers.ModelSerializer):
     current_impact_name = serializers.SerializerMethodField()
     potential_impact_name = serializers.SerializerMethodField()
     potential_threat_onset_name = serializers.SerializerMethodField()
-    occurrence_report = OccurrenceReportSerializer()
+    #occurrence_report = OccurrenceReportSerializer()
 
     class Meta:
         model = OCRConservationThreat

--- a/boranga/frontend/boranga/src/components/common/conservation_status_community_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/conservation_status_community_dashboard.vue
@@ -71,14 +71,28 @@
                 </div>
                 <div class="col-md-3" v-show="!is_for_agenda">
                     <div class="form-group">
-                        <label for="">Effective From Date:</label>
-                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="effective_from_date" v-model="filterCSCommunityEffectiveFromDate">
+                        <label for="">Effective From Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_from_date" v-model="filterCSFromCommunityEffectiveFromDate">
                     </div>
                 </div>
                 <div class="col-md-3" v-show="!is_for_agenda">
                     <div class="form-group">
-                        <label for="">Effective To Date:</label>
-                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="effective_from_date" v-model="filterCSCommunityEffectiveToDate">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_from_date" v-model="filterCSToCommunityEffectiveFromDate">
+                    </div>
+                </div>
+                
+                <div class="col-md-3" v-show="!is_for_agenda">
+                    <div class="form-group">
+                        <label for="">Effective To Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_to_date" v-model="filterCSFromCommunityEffectiveToDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" v-show="!is_for_agenda">
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_to_date" v-model="filterCSToCommunityEffectiveToDate">
                     </div>
                 </div>
             </div>
@@ -193,15 +207,25 @@ export default {
             required: false,
             default: 'filterCSCommunityApplicationStatus',
         },
-        filterCSCommunityEffectiveFromDate_cache: {
+        filterCSFromCommunityEffectiveFromDate_cache: {
             type: String,
             required: false,
-            default: 'filterCSCommunityEffectiveFromDate',
+            default: 'filterCSFromCommunityEffectiveFromDate',
         },
-        filterCSCommunityEffectiveToDate_cache: {
+        filterCSToCommunityEffectiveFromDate_cache: {
             type: String,
             required: false,
-            default: 'filterCSCommunityEffectiveToDate',
+            default: 'filterCSToCommunityEffectiveFromDate',
+        },
+        filterCSFromCommunityEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterCSFromCommunityEffectiveToDate',
+        },
+        filterCSToCommunityEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterCSToCommunityEffectiveToDate',
         },
     },
     data() {
@@ -237,11 +261,15 @@ export default {
             filterCSCommunityApplicationStatus: sessionStorage.getItem(this.filterCSCommunityApplicationStatus_cache) ?
                                     sessionStorage.getItem(this.filterCSCommunityApplicationStatus_cache) : 'all',
 
-            filterCSCommunityEffectiveFromDate: sessionStorage.getItem(this.filterCSCommunityEffectiveFromDate_cache) ?
-                                    sessionStorage.getItem(this.filterCSCommunityEffectiveFromDate_cache) : '',
+            filterCSFromCommunityEffectiveFromDate: sessionStorage.getItem(this.filterCSFromCommunityEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterCSFromCommunityEffectiveFromDate_cache) : '',
+            filterCSToCommunityEffectiveFromDate: sessionStorage.getItem(this.filterCSToCommunityEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterCSToCommunityEffectiveFromDate_cache) : '',
 
-            filterCSCommunityEffectiveToDate: sessionStorage.getItem(this.filterCSCommunityEffectiveToDate_cache) ?
-                                    sessionStorage.getItem(this.filterCSCommunityEffectiveToDate_cache) : '',
+            filterCSFromCommunityEffectiveToDate: sessionStorage.getItem(this.filterCSFromCommunityEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterCSFromCommunityEffectiveToDate_cache) : '',
+            filterCSToCommunityEffectiveToDate: sessionStorage.getItem(this.filterCSToCommunityEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterCSToCommunityEffectiveToDate_cache) : '',
 
             //Filter list for Community select box
             filterListsCommunities: {},
@@ -316,15 +344,25 @@ export default {
             vm.$refs.cs_communities_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
             sessionStorage.setItem(vm.filterCSCommunityDistrict_cache, vm.filterCSCommunityDistrict);
         },
-        filterCSCommunityEffectiveFromDate: function(){
+        filterCSFromCommunityEffectiveFromDate: function(){
             let vm = this;
             vm.$refs.cs_communities_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
-            sessionStorage.setItem(vm.filterCSCommunityEffectiveFromDate_cache, vm.filterCSCommunityEffectiveFromDate);
+            sessionStorage.setItem(vm.filterCSFromCommunityEffectiveFromDate_cache, vm.filterCSFromCommunityEffectiveFromDate);
         },
-        filterCSCommunityEffectiveToDate: function(){
+        filterCSToCommunityEffectiveFromDate: function(){
             let vm = this;
             vm.$refs.cs_communities_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
-            sessionStorage.setItem(vm.filterCSCommunityEffectiveToDate_cache, vm.filterCSCommunityEffectiveToDate);
+            sessionStorage.setItem(vm.filterCSToCommunityEffectiveFromDate_cache, vm.filterCSToCommunityEffectiveFromDate);
+        },
+        filterCSFromCommunityEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.cs_communities_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterCSFromCommunityEffectiveToDate_cache, vm.filterCSFromCommunityEffectiveToDate);
+        },
+        filterCSToCommunityEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.cs_communities_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterCSToCommunityEffectiveToDate_cache, vm.filterCSToCommunityEffectiveToDate);
         },
         filterCSCommunityApplicationStatus: function() {
             let vm = this;
@@ -347,8 +385,10 @@ export default {
                 this.filterCSCommunityRegion === 'all' &&
                 this.filterCSCommunityDistrict === 'all' &&
                 this.filterCSCommunityApplicationStatus === 'all' &&
-                this.filterCSCommunityEffectiveFromDate === '' &&
-                this.filterCSCommunityEffectiveToDate === ''){
+                this.filterCSFromCommunityEffectiveFromDate === '' &&
+                this.filterCSToCommunityEffectiveFromDate === '' &&
+                this.filterCSFromCommunityEffectiveToDate === '' &&
+                this.filterCSToCommunityEffectiveToDate === ''){
                 return false
             } else {
                 return true
@@ -689,8 +729,10 @@ export default {
                         d.filter_region = vm.filterCSCommunityRegion;
                         d.filter_district = vm.filterCSCommunityDistrict;
                         d.filter_application_status = vm.filterCSCommunityApplicationStatus;
-                        d.filter_effective_from_date = vm.filterCSCommunityEffectiveFromDate;
-                        d.filter_effective_to_date = vm.filterCSCommunityEffectiveToDate;
+                        d.filter_from_effective_from_date = vm.filterCSFromCommunityEffectiveFromDate;
+                        d.filter_to_effective_from_date = vm.filterCSToCommunityEffectiveFromDate;
+                        d.filter_from_effective_to_date = vm.filterCSFromCommunityEffectiveToDate;
+                        d.filter_to_effective_to_date = vm.filterCSToCommunityEffectiveToDate;
                         d.is_internal = vm.is_internal;
                     }
                 },
@@ -1119,8 +1161,10 @@ export default {
                 filter_application_status: vm.filterCSCommunityApplicationStatus,
                 filter_region: vm.filterCSCommunityRegion,
                 filter_district: vm.filterCSCommunityDistrict,
-                filter_effective_from_date: vm.filterCSCommunityEffectiveFromDate,
-                filter_effective_to_date: vm.filterCSCommunityEffectiveToDate,
+                filter_from_effective_from_date: vm.filterCSFromCommunityEffectiveFromDate,
+                filter_to_effective_from_date: vm.filterCSToCommunityEffectiveFromDate,
+                filter_effective_to_date: vm.filterCSFromCommunityEffectiveToDate,
+                filter_effective_to_date: vm.filterCSToCommunityEffectiveToDate,
                 is_internal: vm.is_internal,
                 export_format: format
             };

--- a/boranga/frontend/boranga/src/components/common/conservation_status_fauna_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/conservation_status_fauna_dashboard.vue
@@ -101,14 +101,28 @@
                 </div>
                 <div class="col-md-3" v-show="!is_for_agenda">
                     <div class="form-group">
-                        <label for="">Effective From Date:</label>
-                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="effective_from_date" v-model="filterCSFaunaEffectiveFromDate">
+                        <label for="">Effective From Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_from_date" v-model="filterCSFromFaunaEffectiveFromDate">
                     </div>
                 </div>
                 <div class="col-md-3" v-show="!is_for_agenda">
                     <div class="form-group">
-                        <label for="">Effective To Date:</label>
-                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="effective_from_date" v-model="filterCSFaunaEffectiveToDate">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_from_date" v-model="filterCSToFaunaEffectiveFromDate">
+                    </div>
+                </div>
+                
+                <div class="col-md-3" v-show="!is_for_agenda">
+                    <div class="form-group">
+                        <label for="">Effective To Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_to_date" v-model="filterCSFromFaunaEffectiveToDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" v-show="!is_for_agenda">
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_to_date" v-model="filterCSToFaunaEffectiveToDate">
                     </div>
                 </div>
             </div>
@@ -243,15 +257,25 @@ export default {
             required: false,
             default: 'filterCSFaunaApplicationStatus',
         },
-        filterCSFaunaEffectiveFromDate_cache: {
+        filterCSFromFaunaEffectiveFromDate_cache: {
             type: String,
             required: false,
-            default: 'filterCSFaunaEffectiveFromDate',
+            default: 'filterCSFromFaunaEffectiveFromDate',
         },
-        filterCSFaunaEffectiveToDate_cache: {
+        filterCSToFaunaEffectiveFromDate_cache: {
             type: String,
             required: false,
-            default: 'filterCSFaunaEffectiveToDate',
+            default: 'filterCSToFaunaEffectiveFromDate',
+        },
+        filterCSFromFaunaEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterCSFromFaunaEffectiveToDate',
+        },
+        filterCSToFaunaEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterCSToFaunaEffectiveToDate',
         },
     },
     data() {
@@ -296,11 +320,15 @@ export default {
             filterCSFaunaApplicationStatus: sessionStorage.getItem(this.filterCSFaunaApplicationStatus_cache) ?
                                     sessionStorage.getItem(this.filterCSFaunaApplicationStatus_cache) : 'all',
 
-            filterCSFaunaEffectiveFromDate: sessionStorage.getItem(this.filterCSFaunaEffectiveFromDate_cache) ?
-            sessionStorage.getItem(this.filterCSFaunaEffectiveFromDate_cache) : '',
+            filterCSFromFaunaEffectiveFromDate: sessionStorage.getItem(this.filterCSFromFaunaEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterCSFromFaunaEffectiveFromDate_cache) : '',
+            filterCSToFaunaEffectiveFromDate: sessionStorage.getItem(this.filterCSToFaunaEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterCSToFaunaEffectiveFromDate_cache) : '',
 
-            filterCSFaunaEffectiveToDate: sessionStorage.getItem(this.filterCSFaunaEffectiveToDate_cache) ?
-            sessionStorage.getItem(this.filterCSFaunaEffectiveToDate_cache) : '',
+            filterCSFromFaunaEffectiveToDate: sessionStorage.getItem(this.filterCSFromFaunaEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterCSFromFaunaEffectiveToDate_cache) : '',
+            filterCSToFaunaEffectiveToDate: sessionStorage.getItem(this.filterCSToFaunaEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterCSToFaunaEffectiveToDate_cache) : '',
 
             //Filter list for scientific name and common name
             filterListsSpecies: {},
@@ -393,15 +421,25 @@ export default {
             vm.$refs.fauna_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
             sessionStorage.setItem(vm.filterCSFaunaDistrict_cache, vm.filterCSFaunaDistrict);
         },
-        filterCSFaunaEffectiveFromDate: function(){
+        filterCSFromFaunaEffectiveFromDate: function(){
             let vm = this;
             vm.$refs.fauna_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
-            sessionStorage.setItem(vm.filterCSFaunaEffectiveFromDate_cache, vm.filterCSFaunaEffectiveFromDate);
+            sessionStorage.setItem(vm.filterCSFromFaunaEffectiveFromDate_cache, vm.filterCSFromFaunaEffectiveFromDate);
         },
-        filterCSFaunaEffectiveToDate: function(){
+        filterCSToFaunaEffectiveFromDate: function(){
             let vm = this;
             vm.$refs.fauna_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
-            sessionStorage.setItem(vm.filterCSFaunaEffectiveToDate_cache, vm.filterCSFaunaEffectiveToDate);
+            sessionStorage.setItem(vm.filterCSToFaunaEffectiveFromDate_cache, vm.filterCSToFaunaEffectiveFromDate);
+        },
+        filterCSFromFaunaEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.fauna_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterCSFromFaunaEffectiveToDate_cache, vm.filterCSFromFaunaEffectiveToDate);
+        },
+        filterCSToFaunaEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.fauna_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterCSToFaunaEffectiveToDate_cache, vm.filterCSToFaunaEffectiveToDate);
         },
         filterCSFaunaApplicationStatus: function() {
             let vm = this;
@@ -427,8 +465,10 @@ export default {
                 this.filterCSFaunaRegion === 'all' &&
                 this.filterCSFaunaDistrict === 'all' &&
                 this.filterCSFaunaApplicationStatus === 'all' &&
-                this.filterCSFaunaEffectiveFromDate === '' &&
-                this.filterCSFaunaEffectiveToDate === ''){
+                this.filterCSFromFaunaEffectiveFromDate === '' &&
+                this.filterCSToFaunaEffectiveFromDate === '' &&
+                this.filterCSFromFaunaEffectiveToDate === '' &&
+                this.filterCSToFaunaEffectiveToDate === ''){
                 return false
             } else {
                 return true
@@ -811,8 +851,10 @@ export default {
                         d.filter_region = vm.filterCSFaunaRegion;
                         d.filter_district = vm.filterCSFaunaDistrict;
                         d.filter_application_status = vm.filterCSFaunaApplicationStatus;
-                        d.filter_effective_from_date = vm.filterCSFaunaEffectiveFromDate;
-                        d.filter_effective_to_date = vm.filterCSFaunaEffectiveToDate;
+                        d.filter_from_effective_from_date = vm.filterCSFromFaunaEffectiveFromDate;
+                        d.filter_to_effective_from_date = vm.filterCSToFaunaEffectiveFromDate;
+                        d.filter_from_effective_to_date = vm.filterCSFromFaunaEffectiveToDate;
+                        d.filter_to_effective_to_date = vm.filterCSToFaunaEffectiveToDate;
                         d.is_internal = vm.is_internal;
                     }
                 },
@@ -1380,8 +1422,10 @@ export default {
                 filter_application_status: vm.filterCSFaunaApplicationStatus,
                 filter_region: vm.filterCSFaunaRegion,
                 filter_district: vm.filterCSFaunaDistrict,
-                filter_effective_from_date: vm.filterCSFaunaEffectiveFromDate,
-                filter_effective_to_date: vm.filterCSFaunaEffectiveToDate,
+                filter_from_effective_from_date: vm.filterCSFromFaunaEffectiveFromDate,
+                filter_to_effective_from_date: vm.filterCSToFaunaEffectiveFromDate,
+                filter_effective_to_date: vm.filterCSFromFaunaEffectiveToDate,
+                filter_effective_to_date: vm.filterCSToFaunaEffectiveToDate,
                 is_internal: vm.is_internal,
                 export_format: format
             };

--- a/boranga/frontend/boranga/src/components/common/conservation_status_flora_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/conservation_status_flora_dashboard.vue
@@ -101,16 +101,31 @@
                 </div>
                 <div class="col-md-3" v-show="!is_for_agenda">
                     <div class="form-group">
-                        <label for="">Effective From Date:</label>
-                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="effective_from_date" v-model="filterCSFloraEffectiveFromDate">
+                        <label for="">Effective From Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_from_date" v-model="filterCSFromFloraEffectiveFromDate">
                     </div>
                 </div>
                 <div class="col-md-3" v-show="!is_for_agenda">
                     <div class="form-group">
-                        <label for="">Effective To Date:</label>
-                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="effective_from_date" v-model="filterCSFloraEffectiveToDate">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_from_date" v-model="filterCSToFloraEffectiveFromDate">
                     </div>
                 </div>
+                
+                <div class="col-md-3" v-show="!is_for_agenda">
+                    <div class="form-group">
+                        <label for="">Effective To Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_to_date" v-model="filterCSFromFloraEffectiveToDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" v-show="!is_for_agenda">
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_to_date" v-model="filterCSToFloraEffectiveToDate">
+                    </div>
+                </div>
+
             </div>
         </CollapsibleFilters>
 
@@ -245,15 +260,25 @@ export default {
             required: false,
             default: 'filterCSFloraApplicationStatus',
         },
-        filterCSFloraEffectiveFromDate_cache: {
+        filterCSFromFloraEffectiveFromDate_cache: {
             type: String,
             required: false,
-            default: 'filterCSFloraEffectiveFromDate',
+            default: 'filterCSFromFloraEffectiveFromDate',
         },
-        filterCSFloraEffectiveToDate_cache: {
+        filterCSToFloraEffectiveFromDate_cache: {
             type: String,
             required: false,
-            default: 'filterCSFloraEffectiveToDate',
+            default: 'filterCSToFloraEffectiveFromDate',
+        },
+        filterCSFromFloraEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterCSFromFloraEffectiveToDate',
+        },
+        filterCSToFloraEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterCSToFloraEffectiveToDate',
         },
 
     },
@@ -299,11 +324,15 @@ export default {
             filterCSFloraApplicationStatus: sessionStorage.getItem(this.filterCSFloraApplicationStatus_cache) ?
                                     sessionStorage.getItem(this.filterCSFloraApplicationStatus_cache) : 'all',
 
-            filterCSFloraEffectiveFromDate: sessionStorage.getItem(this.filterCSFloraEffectiveFromDate_cache) ?
-            sessionStorage.getItem(this.filterCSFloraEffectiveFromDate_cache) : '',
+            filterCSFromFloraEffectiveFromDate: sessionStorage.getItem(this.filterCSFromFloraEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterCSFromFloraEffectiveFromDate_cache) : '',
+            filterCSToFloraEffectiveFromDate: sessionStorage.getItem(this.filterCSToFloraEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterCSToFloraEffectiveFromDate_cache) : '',
 
-            filterCSFloraEffectiveToDate: sessionStorage.getItem(this.filterCSFloraEffectiveToDate_cache) ?
-            sessionStorage.getItem(this.filterCSFloraEffectiveToDate_cache) : '',
+            filterCSFromFloraEffectiveToDate: sessionStorage.getItem(this.filterCSFromFloraEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterCSFromFloraEffectiveToDate_cache) : '',
+            filterCSToFloraEffectiveToDate: sessionStorage.getItem(this.filterCSToFloraEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterCSToFloraEffectiveToDate_cache) : '',
 
             //Filter list for scientific name and common name
             filterListsSpecies: {},
@@ -395,15 +424,25 @@ export default {
             vm.$refs.flora_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
             sessionStorage.setItem(vm.filterCSFloraDistrict_cache, vm.filterCSFloraDistrict);
         },
-        filterCSFloraEffectiveFromDate: function(){
+        filterCSFromFloraEffectiveFromDate: function(){
             let vm = this;
             vm.$refs.flora_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
-            sessionStorage.setItem(vm.filterCSFloraEffectiveFromDate_cache, vm.filterCSFloraEffectiveFromDate);
+            sessionStorage.setItem(vm.filterCSFromFloraEffectiveFromDate_cache, vm.filterCSFromFloraEffectiveFromDate);
         },
-        filterCSFloraEffectiveToDate: function(){
+        filterCSToFloraEffectiveFromDate: function(){
             let vm = this;
             vm.$refs.flora_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
-            sessionStorage.setItem(vm.filterCSFloraEffectiveToDate_cache, vm.filterCSFloraEffectiveToDate);
+            sessionStorage.setItem(vm.filterCSToFloraEffectiveFromDate_cache, vm.filterCSToFloraEffectiveFromDate);
+        },
+        filterCSFromFloraEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.flora_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterCSFromFloraEffectiveToDate_cache, vm.filterCSFromFloraEffectiveToDate);
+        },
+        filterCSToFloraEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.flora_cs_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterCSToFloraEffectiveToDate_cache, vm.filterCSToFloraEffectiveToDate);
         },
         filterCSFloraApplicationStatus: function() {
             let vm = this;
@@ -429,8 +468,10 @@ export default {
                 this.filterCSFloraRegion === 'all' &&
                 this.filterCSFloraDistrict === 'all' &&
                 this.filterCSFloraApplicationStatus === 'all' &&
-                this.filterCSFloraEffectiveFromDate === '' &&
-                this.filterCSFloraEffectiveToDate === ''){
+                this.filterCSFromFloraEffectiveFromDate === '' &&
+                this.filterCSToFloraEffectiveFromDate === '' &&
+                this.filterCSFromFloraEffectiveToDate === '' &&
+                this.filterCSToFloraEffectiveToDate === ''){
                 return false
             } else {
                 return true
@@ -814,8 +855,10 @@ export default {
                         d.filter_region = vm.filterCSFloraRegion;
                         d.filter_district = vm.filterCSFloraDistrict;
                         d.filter_application_status = vm.filterCSFloraApplicationStatus;
-                        d.filter_effective_from_date = vm.filterCSFloraEffectiveFromDate;
-                        d.filter_effective_to_date = vm.filterCSFloraEffectiveToDate;
+                        d.filter_from_effective_from_date = vm.filterCSFromFloraEffectiveFromDate;
+                        d.filter_to_effective_from_date = vm.filterCSToFloraEffectiveFromDate;
+                        d.filter_from_effective_to_date = vm.filterCSFromFloraEffectiveToDate;
+                        d.filter_to_effective_to_date = vm.filterCSToFloraEffectiveToDate;
                         d.is_internal = vm.is_internal;
                     }
                 },
@@ -1382,8 +1425,10 @@ export default {
                 filter_application_status: vm.filterCSFloraApplicationStatus,
                 filter_region: vm.filterCSFloraRegion,
                 filter_district: vm.filterCSFloraDistrict,
-                filter_effective_from_date: vm.filterCSFloraEffectiveFromDate,
-                filter_effective_to_date: vm.filterCSFloraEffectiveToDate,
+                filter_from_effective_from_date: vm.filterCSFromFloraEffectiveFromDate,
+                filter_to_effective_from_date: vm.filterCSToFloraEffectiveFromDate,
+                filter_effective_to_date: vm.filterCSFromFloraEffectiveToDate,
+                filter_effective_to_date: vm.filterCSToFloraEffectiveToDate,
                 is_internal: vm.is_internal,
                 export_format: format
             };

--- a/boranga/frontend/boranga/src/components/common/occurrence/ocr_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/ocr_threats.vue
@@ -177,10 +177,10 @@ export default {
                         searchable: true,
                         mRender: function (data, type, full) {
                             if (full.visible) {
-                                return "OCR" + full.occurrence_report.id + " - " + full.threat_number;
+                                return "OCR" + full.occurrence_report + " - " + full.threat_number;
                             }
                             else {
-                                return '<s>' + "OCR" + full.occurrence_report.id + " - " + full.threat_number + '</s>'
+                                return '<s>' + "OCR" + full.occurrence_report + " - " + full.threat_number + '</s>'
                             }
                         },
                     },

--- a/boranga/frontend/boranga/src/components/common/occurrence_community_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_community_dashboard.vue
@@ -29,6 +29,47 @@
                             </select>
                     </div>
                 </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective From Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_from_date" v-model="filterOCCFromCommunityEffectiveFromDate">
+                    </div>
+                </div>
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_from_date" v-model="filterOCCToCommunityEffectiveFromDate">
+                    </div>
+                </div>
+                
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective To Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_to_date" v-model="filterOCCFromCommunityEffectiveToDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_to_date" v-model="filterOCCToCommunityEffectiveToDate">
+                    </div>
+                </div>
+
+                <!--<div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Due Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_due_date" v-model="filterOCCFromCommunityDueDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_due_date" v-model="filterOCCToCommunityDueDate">
+                    </div>
+                </div>-->
             </div>
         </CollapsibleFilters>
 
@@ -108,6 +149,36 @@ export default {
             required: false,
             default: 'filterOCCCommunityStatus',
         },
+        filterOCCFromCommunityEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCFromCommunityEffectiveFromDate',
+        },
+        filterOCCToCommunityEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCToCommunityEffectiveFromDate',
+        },
+        filterOCCFromCommunityEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCFromCommunityEffectiveToDate',
+        },
+        filterOCCToCommunityEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCToCommunityEffectiveToDate',
+        },
+        filterOCCFromCommunityDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCFromCommunityDueDate',
+        },
+        filterOCCToCommunityDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCToCommunityDueDate',
+        },
     },
     data() {
         let vm = this;
@@ -122,14 +193,28 @@ export default {
 
             // selected values for filtering
             filterOCCCommunityOccurrenceName: sessionStorage.getItem(this.filterOCCCommunityOccurrenceName_cache) ?
-                                    sessionStorage.getItem(this.filterOCCCommunityOccurrenceName_cache) : 'all',
+                        sessionStorage.getItem(this.filterOCCCommunityOccurrenceName_cache) : 'all',
 
             filterOCCCommunityName: sessionStorage.getItem(this.filterOCCCommunityName_cache) ?
-                                sessionStorage.getItem(this.filterOCCCommunityName_cache) : 'all',
+                        sessionStorage.getItem(this.filterOCCCommunityName_cache) : 'all',
 
             filterOCCCommunityStatus: sessionStorage.getItem(this.filterOCCCommunityStatus_cache) ?
                         sessionStorage.getItem(this.filterOCCCommunityStatus_cache) : 'all',
 
+            filterOCCFromCommunityEffectiveFromDate: sessionStorage.getItem(this.filterOCCFromCommunityEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCCFromCommunityEffectiveFromDate_cache) : '',
+            filterOCCToCommunityEffectiveFromDate: sessionStorage.getItem(this.filterOCCToCommunityEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCCToCommunityEffectiveFromDate_cache) : '',
+
+            filterOCCFromCommunityEffectiveToDate: sessionStorage.getItem(this.filterOCCFromCommunityEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCCFromCommunityEffectiveToDate_cache) : '',
+            filterOCCToCommunityEffectiveToDate: sessionStorage.getItem(this.filterOCCToCommunityEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCCToCommunityEffectiveToDate_cache) : '',
+
+            filterOCCFromCommunityDueDate: sessionStorage.getItem(this.filterOCCFromCommunityDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCCFromCommunityDueDate_cache) : '',
+            filterOCCToCommunityDueDate: sessionStorage.getItem(this.filterOCCToCommunityDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCCToCommunityDueDate_cache) : '',
 
             filterListsCommunity: {},
             occurrence_list: [],
@@ -181,12 +266,48 @@ export default {
                 this.$refs.collapsible_filters.show_warning_icon(this.filterApplied)
             }
         },
+        filterOCCFromCommunityEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.community_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCFromCommunityEffectiveFromDate_cache, vm.filterOCCFromCommunityEffectiveFromDate);
+        },
+        filterOCCToCommunityEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.community_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCToCommunityEffectiveFromDate_cache, vm.filterOCCToCommunityEffectiveFromDate);
+        },
+        filterOCCFromCommunityEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.community_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCFromCommunityEffectiveToDate_cache, vm.filterOCCFromCommunityEffectiveToDate);
+        },
+        filterOCCToCommunityEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.community_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCToCommunityEffectiveToDate_cache, vm.filterOCCToCommunityEffectiveToDate);
+        },
+        filterOCCFromCommunityDueDate: function(){
+            let vm = this;
+            vm.$refs.community_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCFromCommunityDueDate_cache, vm.filterOCCFromCommunityDueDate);
+        },
+        filterOCCToCommunityDueDate: function(){
+            let vm = this;
+            vm.$refs.community_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCToCommunityDueDate_cache, vm.filterOCCToCommunityDueDate);
+        },
     },
     computed: {
         filterApplied: function(){
             if(this.filterOCCCommunityOccurrenceName === 'all' &&
                 this.filterOCCCommunityName === 'all' &&
-                this.filterOCCCommunityStatus === 'all'){
+                this.filterOCCCommunityStatus === 'all' &&
+                this.filterOCCFromCommunityEffectiveFromDate === '' &&
+                this.filterOCCToCommunityEffectiveFromDate === '' &&
+                this.filterOCCFromCommunityEffectiveToDate === '' &&
+                this.filterOCCToCommunityEffectiveToDate === '' &&
+                this.filterOCCFromCommunityDueDate === '' &&
+                this.filterOCCToCommunityDueDate === ''){
                 return false
             } else {
                 return true
@@ -393,6 +514,12 @@ export default {
                         d.filter_occurrence_name = vm.filterOCCCommunityOccurrenceName;
                         d.filter_community_name = vm.filterOCCCommunityName;
                         d.filter_status = vm.filterOCCCommunityStatus;
+                        d.filter_from_effective_from_date = vm.filterOCCFromCommunityEffectiveFromDate;
+                        d.filter_to_effective_from_date = vm.filterOCCToCommunityEffectiveFromDate;
+                        d.filter_from_effective_to_date = vm.filterOCCFromCommunityEffectiveToDate;
+                        d.filter_to_effective_to_date = vm.filterOCCToCommunityEffectiveToDate;
+                        d.filter_from_due_date = vm.filterOCCFromCommunityDueDate;
+                        d.filter_to_due_date = vm.filterOCCToCommunityDueDate;
                         d.is_internal = vm.is_internal;
                     }
                 },
@@ -575,7 +702,7 @@ export default {
             vm.$refs.community_occ_datatable.vmDataTable.on('click', 'a[data-discard-ocr-proposal]', function(e) {
                 e.preventDefault();
                 var id = $(this).attr('data-discard-ocr-proposal');
-                vm.discardCSProposal(id);
+                vm.discardOCCProposal(id);
             });
             vm.$refs.community_occ_datatable.vmDataTable.on('click', 'a[data-history-occurrence]', function(e) {
                     e.preventDefault();
@@ -670,6 +797,12 @@ export default {
                 filter_occurrence_name: vm.filterOCCCommunityOccurrenceName,
                 filter_community_name: vm.filterOCCCommunityName,
                 filter_status: vm.filterOCCCommunityStatus,
+                filter_from_effective_from_date: vm.filterOCCFromCommunityEffectiveFromDate,
+                filter_to_effective_from_date: vm.filterOCCToCommunityEffectiveFromDate,
+                filter_from_effective_to_date: vm.filterOCCFromCommunityEffectiveToDate,
+                filter_to_effective_to_date: vm.filterOCCToCommunityEffectiveToDate,
+                filter_from_due_date: vm.filterOCCFromCommunityDueDate,
+                filter_to_due_date: vm.filterOCCToCommunityDueDate,
                 is_internal: vm.is_internal,
                 export_format: format
             };

--- a/boranga/frontend/boranga/src/components/common/occurrence_fauna_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_fauna_dashboard.vue
@@ -29,6 +29,48 @@
                     </div>
                 </div>
             </div>
+            <div class="row">
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective From Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_from_date" v-model="filterOCCFromFaunaEffectiveFromDate">
+                    </div>
+                </div>
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_from_date" v-model="filterOCCToFaunaEffectiveFromDate">
+                    </div>
+                </div>
+                
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective To Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_to_date" v-model="filterOCCFromFaunaEffectiveToDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_to_date" v-model="filterOCCToFaunaEffectiveToDate">
+                    </div>
+                </div>
+
+                <!--<div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Due Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_due_date" v-model="filterOCCFromFaunaDueDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_due_date" v-model="filterOCCToFaunaDueDate">
+                    </div>
+                </div>-->
+            </div>
         </CollapsibleFilters>
 
         <div class="col-md-12">
@@ -110,6 +152,36 @@ export default {
             required: false,
             default: 'filterOCCFaunaStatus',
         },
+        filterOCCFromFaunaEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCFromFaunaEffectiveFromDate',
+        },
+        filterOCCToFaunaEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCToFaunaEffectiveFromDate',
+        },
+        filterOCCFromFaunaEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCFromFaunaEffectiveToDate',
+        },
+        filterOCCToFaunaEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCToFaunaEffectiveToDate',
+        },
+        filterOCCFromFaunaDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCFromFaunaDueDate',
+        },
+        filterOCCToFaunaDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCToFaunaDueDate',
+        },
     },
     data() {
         let vm = this;
@@ -131,6 +203,21 @@ export default {
 
             filterOCCFaunaStatus: sessionStorage.getItem(this.filterOCCFaunaStatus_cache) ?
                 sessionStorage.getItem(this.filterOCCFaunaStatus_cache) : 'all',
+
+            filterOCCFromFaunaEffectiveFromDate: sessionStorage.getItem(this.filterOCCFromFaunaEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCCFromFaunaEffectiveFromDate_cache) : '',
+            filterOCCToFaunaEffectiveFromDate: sessionStorage.getItem(this.filterOCCToFaunaEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCCToFaunaEffectiveFromDate_cache) : '',
+
+            filterOCCFromFaunaEffectiveToDate: sessionStorage.getItem(this.filterOCCFromFaunaEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCCFromFaunaEffectiveToDate_cache) : '',
+            filterOCCToFaunaEffectiveToDate: sessionStorage.getItem(this.filterOCCToFaunaEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCCToFaunaEffectiveToDate_cache) : '',
+
+            filterOCCFromFaunaDueDate: sessionStorage.getItem(this.filterOCCFromFaunaDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCCFromFaunaDueDate_cache) : '',
+            filterOCCToFaunaDueDate: sessionStorage.getItem(this.filterOCCToFaunaDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCCToFaunaDueDate_cache) : '',
 
             filterListsSpecies: {},
             occurrence_list: [],
@@ -177,12 +264,48 @@ export default {
                 this.$refs.collapsible_filters.show_warning_icon(this.filterApplied)
             }
         },
+        filterOCCFromFaunaEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.fauna_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCFromFaunaEffectiveFromDate_cache, vm.filterOCCFromFaunaEffectiveFromDate);
+        },
+        filterOCCToFaunaEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.fauna_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCToFaunaEffectiveFromDate_cache, vm.filterOCCToFaunaEffectiveFromDate);
+        },
+        filterOCCFromFaunaEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.fauna_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCFromFaunaEffectiveToDate_cache, vm.filterOCCFromFaunaEffectiveToDate);
+        },
+        filterOCCToFaunaEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.fauna_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCToFaunaEffectiveToDate_cache, vm.filterOCCToFaunaEffectiveToDate);
+        },
+        filterOCCFromFaunaDueDate: function(){
+            let vm = this;
+            vm.$refs.fauna_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCFromFaunaDueDate_cache, vm.filterOCCFromFaunaDueDate);
+        },
+        filterOCCToFaunaDueDate: function(){
+            let vm = this;
+            vm.$refs.fauna_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCToFaunaDueDate_cache, vm.filterOCCToFaunaDueDate);
+        },
     },
     computed: {
         filterApplied: function () {
             if (this.filterOCCFaunaOccurrenceName === 'all' &&
                 this.filterOCCFaunaScientificName === 'all' &&
-                this.filterOCCFaunaStatus === 'all') {
+                this.filterOCCFaunaStatus === 'all' &&
+                this.filterOCCFromFaunaEffectiveFromDate === '' &&
+                this.filterOCCToFaunaEffectiveFromDate === '' &&
+                this.filterOCCFromFaunaEffectiveToDate === '' &&
+                this.filterOCCToFaunaEffectiveToDate === '' &&
+                this.filterOCCFromFaunaDueDate === '' &&
+                this.filterOCCToFaunaDueDate === '') {
                 return false
             } else {
                 return true
@@ -374,6 +497,12 @@ export default {
                         d.filter_occurrence_name = vm.filterOCCFaunaOccurrenceName;
                         d.filter_scientific_name = vm.filterOCCFaunaScientificName;
                         d.filter_status = vm.filterOCCFaunaStatus;
+                        d.filter_from_effective_from_date = vm.filterOCCFromFaunaEffectiveFromDate;
+                        d.filter_to_effective_from_date = vm.filterOCCToFaunaEffectiveFromDate;
+                        d.filter_from_effective_to_date = vm.filterOCCFromFaunaEffectiveToDate;
+                        d.filter_to_effective_to_date = vm.filterOCCToFaunaEffectiveToDate;
+                        d.filter_from_due_date = vm.filterOCCFromFaunaDueDate;
+                        d.filter_to_due_date = vm.filterOCCToFaunaDueDate;
                         d.is_internal = vm.is_internal;
                     }
                 },
@@ -648,6 +777,12 @@ export default {
                 filter_occurrence_name: vm.filterOCCFaunaOccurrenceName,
                 filter_scientific_name: vm.filterOCCFaunaScientificName,
                 filter_status: vm.filterOCCFaunaStatus,
+                filter_from_effective_from_date: vm.filterOCCFromFaunaEffectiveFromDate,
+                filter_to_effective_from_date: vm.filterOCCToFaunaEffectiveFromDate,
+                filter_from_effective_to_date: vm.filterOCCFromFaunaEffectiveToDate,
+                filter_to_effective_to_date: vm.filterOCCToFaunaEffectiveToDate,
+                filter_from_due_date: vm.filterOCCFromFaunaDueDate,
+                filter_to_due_date: vm.filterOCCToFaunaDueDate,
                 is_internal: vm.is_internal,
                 export_format: format
             };

--- a/boranga/frontend/boranga/src/components/common/occurrence_flora_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_flora_dashboard.vue
@@ -29,6 +29,48 @@
                     </div>
                 </div>
             </div>
+            <div class="row">
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective From Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_from_date" v-model="filterOCCFromFloraEffectiveFromDate">
+                    </div>
+                </div>
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_from_date" v-model="filterOCCToFloraEffectiveFromDate">
+                    </div>
+                </div>
+                
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective To Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_to_date" v-model="filterOCCFromFloraEffectiveToDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_to_date" v-model="filterOCCToFloraEffectiveToDate">
+                    </div>
+                </div>
+
+                <!--<div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Due Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_due_date" v-model="filterOCCFromFloraDueDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_due_date" v-model="filterOCCToFloraDueDate">
+                    </div>
+                </div>-->
+            </div>
         </CollapsibleFilters>
 
         <div class="col-md-12">
@@ -110,6 +152,36 @@ export default {
             required: false,
             default: 'filterOCCFloraStatus',
         },
+        filterOCCFromFloraEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCFromFloraEffectiveFromDate',
+        },
+        filterOCCToFloraEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCToFloraEffectiveFromDate',
+        },
+        filterOCCFromFloraEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCFromFloraEffectiveToDate',
+        },
+        filterOCCToFloraEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCToFloraEffectiveToDate',
+        },
+        filterOCCFromFloraDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCFromFloraDueDate',
+        },
+        filterOCCToFloraDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCCToFloraDueDate',
+        },
     },
     data() {
         let vm = this;
@@ -131,6 +203,21 @@ export default {
 
             filterOCCFloraStatus: sessionStorage.getItem(this.filterOCCFloraStatus_cache) ?
                 sessionStorage.getItem(this.filterOCCFloraStatus_cache) : 'all',
+
+            filterOCCFromFloraEffectiveFromDate: sessionStorage.getItem(this.filterOCCFromFloraEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCCFromFloraEffectiveFromDate_cache) : '',
+            filterOCCToFloraEffectiveFromDate: sessionStorage.getItem(this.filterOCCToFloraEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCCToFloraEffectiveFromDate_cache) : '',
+
+            filterOCCFromFloraEffectiveToDate: sessionStorage.getItem(this.filterOCCFromFloraEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCCFromFloraEffectiveToDate_cache) : '',
+            filterOCCToFloraEffectiveToDate: sessionStorage.getItem(this.filterOCCToFloraEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCCToFloraEffectiveToDate_cache) : '',
+
+            filterOCCFromFloraDueDate: sessionStorage.getItem(this.filterOCCFromFloraDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCCFromFloraDueDate_cache) : '',
+            filterOCCToFloraDueDate: sessionStorage.getItem(this.filterOCCToFloraDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCCToFloraDueDate_cache) : '',
 
             filterListsSpecies: {},
             occurrence_list: [],
@@ -177,12 +264,48 @@ export default {
                 this.$refs.collapsible_filters.show_warning_icon(this.filterApplied)
             }
         },
+        filterOCCFromFloraEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.flora_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCFromFloraEffectiveFromDate_cache, vm.filterOCCFromFloraEffectiveFromDate);
+        },
+        filterOCCToFloraEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.flora_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCToFloraEffectiveFromDate_cache, vm.filterOCCToFloraEffectiveFromDate);
+        },
+        filterOCCFromFloraEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.flora_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCFromFloraEffectiveToDate_cache, vm.filterOCCFromFloraEffectiveToDate);
+        },
+        filterOCCToFloraEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.flora_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCToFloraEffectiveToDate_cache, vm.filterOCCToFloraEffectiveToDate);
+        },
+        filterOCCFromFloraDueDate: function(){
+            let vm = this;
+            vm.$refs.flora_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCFromFloraDueDate_cache, vm.filterOCCFromFloraDueDate);
+        },
+        filterOCCToFloraDueDate: function(){
+            let vm = this;
+            vm.$refs.flora_occ_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCCToFloraDueDate_cache, vm.filterOCCToFloraDueDate);
+        },
     },
     computed: {
         filterApplied: function () {
             if (this.filterOCCFloraOccurrenceName === 'all' &&
                 this.filterOCCFloraScientificName === 'all' &&
-                this.filterOCCFloraStatus === 'all') {
+                this.filterOCCFloraStatus === 'all' &&
+                this.filterOCCFromFloraEffectiveFromDate === '' &&
+                this.filterOCCToFloraEffectiveFromDate === '' &&
+                this.filterOCCFromFloraEffectiveToDate === '' &&
+                this.filterOCCToFloraEffectiveToDate === '' &&
+                this.filterOCCFromFloraDueDate === '' &&
+                this.filterOCCToFloraDueDate === '') {
                 return false
             } else {
                 return true
@@ -375,6 +498,12 @@ export default {
                     d.filter_occurrence_name = vm.filterOCCFloraOccurrenceName;
                     d.filter_scientific_name = vm.filterOCCFloraScientificName;
                     d.filter_status = vm.filterOCCFloraStatus;
+                    d.filter_from_effective_from_date = vm.filterOCCFromFloraEffectiveFromDate;
+                    d.filter_to_effective_from_date = vm.filterOCCToFloraEffectiveFromDate;
+                    d.filter_from_effective_to_date = vm.filterOCCFromFloraEffectiveToDate;
+                    d.filter_to_effective_to_date = vm.filterOCCToFloraEffectiveToDate;
+                    d.filter_from_due_date = vm.filterOCCFromFloraDueDate;
+                    d.filter_to_due_date = vm.filterOCCToFloraDueDate;
                     d.is_internal = vm.is_internal;
                 }
             },
@@ -646,6 +775,12 @@ methods: {
             filter_occurrence_name: vm.filterOCCFloraOccurrenceName,
             filter_scientific_name: vm.filterOCCFloraScientificName,
             filter_status: vm.filterOCCFloraStatus,
+            filter_from_effective_from_date: vm.filterOCCFromFloraEffectiveFromDate,
+            filter_to_effective_from_date: vm.filterOCCToFloraEffectiveFromDate,
+            filter_from_effective_to_date: vm.filterOCCFromFloraEffectiveToDate,
+            filter_to_effective_to_date: vm.filterOCCToFloraEffectiveToDate,
+            filter_from_due_date: vm.filterOCCFromFloraDueDate,
+            filter_to_due_date: vm.filterOCCToFloraDueDate,
             is_internal: vm.is_internal,
             export_format: format
         };

--- a/boranga/frontend/boranga/src/components/common/occurrence_report_community_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_report_community_dashboard.vue
@@ -31,18 +31,59 @@
                             </select>
                     </div>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <div class="form-group">
-                        <label for="">Submitted From Date:</label>
+                        <label for="">Submitted Date Range:</label>
                         <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="submitted_from_date" v-model="filterOCRCommunitySubmittedFromDate">
                     </div>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <div class="form-group">
-                        <label for="">Submitted To Date:</label>
+                        <label for=""></label>
                         <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="submitted_from_date" v-model="filterOCRCommunitySubmittedToDate">
                     </div>
                 </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective From Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_from_date" v-model="filterOCRFromCommunityEffectiveFromDate">
+                    </div>
+                </div>
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_from_date" v-model="filterOCRToCommunityEffectiveFromDate">
+                    </div>
+                </div>
+                
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective To Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_to_date" v-model="filterOCRFromCommunityEffectiveToDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_to_date" v-model="filterOCRToCommunityEffectiveToDate">
+                    </div>
+                </div>
+
+                <!--<div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Due Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_due_date" v-model="filterOCRFromCommunityDueDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_due_date" v-model="filterOCRToCommunityDueDate">
+                    </div>
+                </div>-->
             </div>
         </CollapsibleFilters>
 
@@ -132,6 +173,36 @@ export default {
             required: false,
             default: 'filterOCRCommunitySubmittedToDate',
         },
+        filterOCRFromCommunityEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRFromCommunityEffectiveFromDate',
+        },
+        filterOCRToCommunityEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRToCommunityEffectiveFromDate',
+        },
+        filterOCRFromCommunityEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRFromCommunityEffectiveToDate',
+        },
+        filterOCRToCommunityEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRToCommunityEffectiveToDate',
+        },
+        filterOCRFromCommunityDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRFromCommunityDueDate',
+        },
+        filterOCRToCommunityDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRToCommunityDueDate',
+        },
     },
     data() {
         let vm = this;
@@ -159,6 +230,21 @@ export default {
 
             filterOCRCommunitySubmittedToDate: sessionStorage.getItem(this.filterOCRCommunitySubmittedToDate_cache) ?
                                 sessionStorage.getItem(this.filterOCRCommunitySubmittedToDate_cache) : '',
+
+            filterOCRFromCommunityEffectiveFromDate: sessionStorage.getItem(this.filterOCRFromCommunityEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCRFromCommunityEffectiveFromDate_cache) : '',
+            filterOCRToCommunityEffectiveFromDate: sessionStorage.getItem(this.filterOCRToCommunityEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCRToCommunityEffectiveFromDate_cache) : '',
+
+            filterOCRFromCommunityEffectiveToDate: sessionStorage.getItem(this.filterOCRFromCommunityEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCRFromCommunityEffectiveToDate_cache) : '',
+            filterOCRToCommunityEffectiveToDate: sessionStorage.getItem(this.filterOCRToCommunityEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCRToCommunityEffectiveToDate_cache) : '',
+
+            filterOCRFromCommunityDueDate: sessionStorage.getItem(this.filterOCRFromCommunityDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCRFromCommunityDueDate_cache) : '',
+            filterOCRToCommunityDueDate: sessionStorage.getItem(this.filterOCRToCommunityDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCRToCommunityDueDate_cache) : '',
 
             filterListsCommunity: {},
             occurrence_list: [],
@@ -217,6 +303,36 @@ export default {
             vm.$refs.community_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
             sessionStorage.setItem(vm.filterOCRCommunitySubmittedToDate_cache, vm.filterOCRCommunitySubmittedToDate);
         },
+        filterOCRFromCommunityEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.community_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRFromCommunityEffectiveFromDate_cache, vm.filterOCRFromCommunityEffectiveFromDate);
+        },
+        filterOCRToCommunityEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.community_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRToCommunityEffectiveFromDate_cache, vm.filterOCRToCommunityEffectiveFromDate);
+        },
+        filterOCRFromCommunityEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.community_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRFromCommunityEffectiveToDate_cache, vm.filterOCRFromCommunityEffectiveToDate);
+        },
+        filterOCRToCommunityEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.community_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRToCommunityEffectiveToDate_cache, vm.filterOCRToCommunityEffectiveToDate);
+        },
+        filterOCRFromCommunityDueDate: function(){
+            let vm = this;
+            vm.$refs.community_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRFromCommunityDueDate_cache, vm.filterOCRFromCommunityDueDate);
+        },
+        filterOCRToCommunityDueDate: function(){
+            let vm = this;
+            vm.$refs.community_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRToCommunityDueDate_cache, vm.filterOCRToCommunityDueDate);
+        },
         filterApplied: function(){
             if (this.$refs.collapsible_filters){
                 // Collapsible component exists
@@ -230,7 +346,13 @@ export default {
                 this.filterOCRCommunityName === 'all' &&
                 this.filterOCRCommunityStatus === 'all' &&
                 this.filterOCRCommunitySubmittedFromDate === '' &&
-                this.filterOCRCommunitySubmittedToDate === ''){
+                this.filterOCRCommunitySubmittedToDate === ''&&
+                this.filterOCRFromCommunityEffectiveFromDate === '' &&
+                this.filterOCRToCommunityEffectiveFromDate === '' &&
+                this.filterOCRFromCommunityEffectiveToDate === '' &&
+                this.filterOCRToCommunityEffectiveToDate === '' &&
+                this.filterOCRFromCommunityDueDate === '' &&
+                this.filterOCRToCommunityDueDate === ''){
                 return false
             } else {
                 return true
@@ -480,6 +602,12 @@ export default {
                         d.filter_status = vm.filterOCRCommunityStatus;
                         d.filter_submitted_from_date = vm.filterOCRCommunitySubmittedFromDate;
                         d.filter_submitted_to_date = vm.filterOCRCommunitySubmittedToDate;
+                        d.filter_from_effective_from_date = vm.filterOCRFromCommunityEffectiveFromDate;
+                        d.filter_to_effective_from_date = vm.filterOCRToCommunityEffectiveFromDate;
+                        d.filter_from_effective_to_date = vm.filterOCRFromCommunityEffectiveToDate;
+                        d.filter_to_effective_to_date = vm.filterOCRToCommunityEffectiveToDate;
+                        d.filter_from_due_date = vm.filterOCRFromCommunityDueDate;
+                        d.filter_to_due_date = vm.filterOCRToCommunityDueDate;
                         d.is_internal = vm.is_internal;
                     }
                 },
@@ -771,6 +899,12 @@ export default {
                 filter_status: vm.filterOCRCommunityStatus,
                 filter_submitted_from_date: vm.filterOCRCommunitySubmittedFromDate,
                 filter_submitted_to_date: vm.filterOCRCommunitySubmittedToDate,
+                filter_from_effective_from_date: vm.filterOCRFromCommunityEffectiveFromDate,
+                filter_to_effective_from_date: vm.filterOCRToCommunityEffectiveFromDate,
+                filter_from_effective_to_date: vm.filterOCRFromCommunityEffectiveToDate,
+                filter_to_effective_to_date: vm.filterOCRToCommunityEffectiveToDate,
+                filter_from_due_date: vm.filterOCRFromCommunityDueDate,
+                filter_to_due_date: vm.filterOCRToCommunityDueDate,
                 is_internal: vm.is_internal,
                 export_format: format
             };

--- a/boranga/frontend/boranga/src/components/common/occurrence_report_fauna_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_report_fauna_dashboard.vue
@@ -41,6 +41,46 @@
                             v-model="filterOCRFaunaSubmittedToDate">
                     </div>
                 </div>
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective From Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_from_date" v-model="filterOCRFromFaunaEffectiveFromDate">
+                    </div>
+                </div>
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_from_date" v-model="filterOCRToFaunaEffectiveFromDate">
+                    </div>
+                </div>
+                
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective To Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_to_date" v-model="filterOCRFromFaunaEffectiveToDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_to_date" v-model="filterOCRToFaunaEffectiveToDate">
+                    </div>
+                </div>
+
+                <!--<div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Due Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_due_date" v-model="filterOCRFromFaunaDueDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_due_date" v-model="filterOCRToFaunaDueDate">
+                    </div>
+                </div>-->
             </div>
         </CollapsibleFilters>
         <div v-if="addFaunaOCRVisibility" class="col-md-12">
@@ -129,7 +169,36 @@ export default {
             required: false,
             default: 'filterOCRFaunaSubmittedToDate',
         },
-
+        filterOCRFromFaunaEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRFromFaunaEffectiveFromDate',
+        },
+        filterOCRToFaunaEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRToFaunaEffectiveFromDate',
+        },
+        filterOCRFromFaunaEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRFromFaunaEffectiveToDate',
+        },
+        filterOCRToFaunaEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRToFaunaEffectiveToDate',
+        },
+        filterOCRFromFaunaDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRFromFaunaDueDate',
+        },
+        filterOCRToFaunaDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRToFaunaDueDate',
+        },
     },
     data() {
         let vm = this;
@@ -157,6 +226,21 @@ export default {
 
             filterOCRFaunaSubmittedToDate: sessionStorage.getItem(this.filterOCRFaunaSubmittedToDate_cache) ?
                 sessionStorage.getItem(this.filterOCRFaunaSubmittedToDate_cache) : '',
+
+            filterOCRFromFaunaEffectiveFromDate: sessionStorage.getItem(this.filterOCRFromFaunaEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCRFromFaunaEffectiveFromDate_cache) : '',
+            filterOCRToFaunaEffectiveFromDate: sessionStorage.getItem(this.filterOCRToFaunaEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCRToFaunaEffectiveFromDate_cache) : '',
+
+            filterOCRFromFaunaEffectiveToDate: sessionStorage.getItem(this.filterOCRFromFaunaEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCRFromFaunaEffectiveToDate_cache) : '',
+            filterOCRToFaunaEffectiveToDate: sessionStorage.getItem(this.filterOCRToFaunaEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCRToFaunaEffectiveToDate_cache) : '',
+
+            filterOCRFromFaunaDueDate: sessionStorage.getItem(this.filterOCRFromFaunaDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCRFromFaunaDueDate_cache) : '',
+            filterOCRToFaunaDueDate: sessionStorage.getItem(this.filterOCRToFaunaDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCRToFaunaDueDate_cache) : '',
 
             filterListsSpecies: {},
             occurrence_list: [],
@@ -212,6 +296,36 @@ export default {
             vm.$refs.fauna_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers, false); // This calls ajax() backend call.
             sessionStorage.setItem(vm.filterOCRFaunaSubmittedToDate_cache, vm.filterOCRFaunaSubmittedToDate);
         },
+        filterOCRFromFaunaEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.fauna_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRFromFaunaEffectiveFromDate_cache, vm.filterOCRFromFaunaEffectiveFromDate);
+        },
+        filterOCRToFaunaEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.fauna_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRToFaunaEffectiveFromDate_cache, vm.filterOCRToFaunaEffectiveFromDate);
+        },
+        filterOCRFromFaunaEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.fauna_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRFromFaunaEffectiveToDate_cache, vm.filterOCRFromFaunaEffectiveToDate);
+        },
+        filterOCRToFaunaEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.fauna_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRToFaunaEffectiveToDate_cache, vm.filterOCRToFaunaEffectiveToDate);
+        },
+        filterOCRFromFaunaDueDate: function(){
+            let vm = this;
+            vm.$refs.fauna_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRFromFaunaDueDate_cache, vm.filterOCRFromFaunaDueDate);
+        },
+        filterOCRToFaunaDueDate: function(){
+            let vm = this;
+            vm.$refs.fauna_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRToFaunaDueDate_cache, vm.filterOCRToFaunaDueDate);
+        },
         filterApplied: function () {
             if (this.$refs.collapsible_filters) {
                 // Collapsible component exists
@@ -225,7 +339,13 @@ export default {
                 this.filterOCRFaunaScientificName === 'all' &&
                 this.filterOCRFaunaStatus === 'all' &&
                 this.filterOCRFaunaSubmittedFromDate === '' &&
-                this.filterOCRFaunaSubmittedToDate === '') {
+                this.filterOCRFaunaSubmittedToDate === '' &&
+                this.filterOCRFromFaunaEffectiveFromDate === '' &&
+                this.filterOCRToFaunaEffectiveFromDate === '' &&
+                this.filterOCRFromFaunaEffectiveToDate === '' &&
+                this.filterOCRToFaunaEffectiveToDate === '' &&
+                this.filterOCRFromFaunaDueDate === '' &&
+                this.filterOCRToFaunaDueDate === '') {
                 return false
             } else {
                 return true
@@ -472,6 +592,12 @@ export default {
                         d.filter_status = vm.filterOCRFaunaStatus;
                         d.filter_submitted_from_date = vm.filterOCRFaunaSubmittedFromDate;
                         d.filter_submitted_to_date = vm.filterOCRFaunaSubmittedToDate;
+                        d.filter_from_effective_from_date = vm.filterOCRFromFaunaEffectiveFromDate;
+                        d.filter_to_effective_from_date = vm.filterOCRToFaunaEffectiveFromDate;
+                        d.filter_from_effective_to_date = vm.filterOCRFromFaunaEffectiveToDate;
+                        d.filter_to_effective_to_date = vm.filterOCRToFaunaEffectiveToDate;
+                        d.filter_from_due_date = vm.filterOCRFromFaunaDueDate;
+                        d.filter_to_due_date = vm.filterOCRToFaunaDueDate;
                         d.is_internal = vm.is_internal;
                     }
                 },
@@ -764,6 +890,12 @@ export default {
                 filter_status: vm.filterOCRFaunaStatus,
                 filter_submitted_from_date: vm.filterOCRFaunaSubmittedFromDate,
                 filter_submitted_to_date: vm.filterOCRFaunaSubmittedToDate,
+                filter_from_effective_from_date: vm.filterOCRFromFaunaEffectiveFromDate,
+                filter_to_effective_from_date: vm.filterOCRToFaunaEffectiveFromDate,
+                filter_from_effective_to_date: vm.filterOCRFromFaunaEffectiveToDate,
+                filter_to_effective_to_date: vm.filterOCRToFaunaEffectiveToDate,
+                filter_from_due_date: vm.filterOCRFromFaunaDueDate,
+                filter_to_due_date: vm.filterOCRToFaunaDueDate,
                 is_internal: vm.is_internal,
                 export_format: format
             };

--- a/boranga/frontend/boranga/src/components/common/occurrence_report_flora_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_report_flora_dashboard.vue
@@ -41,6 +41,46 @@
                             v-model="filterOCRFloraSubmittedToDate">
                     </div>
                 </div>
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective From Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_from_date" v-model="filterOCRFromFloraEffectiveFromDate">
+                    </div>
+                </div>
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_from_date" v-model="filterOCRToFloraEffectiveFromDate">
+                    </div>
+                </div>
+                
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Effective To Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_effective_to_date" v-model="filterOCRFromFloraEffectiveToDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_effective_to_date" v-model="filterOCRToFloraEffectiveToDate">
+                    </div>
+                </div>
+
+                <!--<div class="col-md-3" >
+                    <div class="form-group">
+                        <label for="">Due Date Range:</label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="from_due_date" v-model="filterOCRFromFloraDueDate">
+                    </div>
+                </div>
+
+                <div class="col-md-3" >
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="to_due_date" v-model="filterOCRToFloraDueDate">
+                    </div>
+                </div>-->
             </div>
         </CollapsibleFilters>
         <div v-if="addFloraOCRVisibility" class="col-md-12">
@@ -134,7 +174,36 @@ export default {
             required: false,
             default: 'filterOCRFloraSubmittedToDate',
         },
-
+        filterOCRFromFloraEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRFromFloraEffectiveFromDate',
+        },
+        filterOCRToFloraEffectiveFromDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRToFloraEffectiveFromDate',
+        },
+        filterOCRFromFloraEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRFromFloraEffectiveToDate',
+        },
+        filterOCRToFloraEffectiveToDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRToFloraEffectiveToDate',
+        },
+        filterOCRFromFloraDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRFromFloraDueDate',
+        },
+        filterOCRToFloraDueDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterOCRToFloraDueDate',
+        },
     },
     data() {
         let vm = this;
@@ -162,6 +231,22 @@ export default {
 
             filterOCRFloraSubmittedToDate: sessionStorage.getItem(this.filterOCRFloraSubmittedToDate_cache) ?
                 sessionStorage.getItem(this.filterOCRFloraSubmittedToDate_cache) : '',
+
+            filterOCRFromFloraEffectiveFromDate: sessionStorage.getItem(this.filterOCRFromFloraEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCRFromFloraEffectiveFromDate_cache) : '',
+            filterOCRToFloraEffectiveFromDate: sessionStorage.getItem(this.filterOCRToFloraEffectiveFromDate_cache) ?
+            sessionStorage.getItem(this.filterOCRToFloraEffectiveFromDate_cache) : '',
+
+            filterOCRFromFloraEffectiveToDate: sessionStorage.getItem(this.filterOCRFromFloraEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCRFromFloraEffectiveToDate_cache) : '',
+            filterOCRToFloraEffectiveToDate: sessionStorage.getItem(this.filterOCRToFloraEffectiveToDate_cache) ?
+            sessionStorage.getItem(this.filterOCRToFloraEffectiveToDate_cache) : '',
+
+            filterOCRFromFloraDueDate: sessionStorage.getItem(this.filterOCRFromFloraDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCRFromFloraDueDate_cache) : '',
+            filterOCRToFloraDueDate: sessionStorage.getItem(this.filterOCRToFloraDueDate_cache) ?
+            sessionStorage.getItem(this.filterOCRToFloraDueDate_cache) : '',
+
 
             filterListsSpecies: {},
             occurrence_list: [],
@@ -215,6 +300,36 @@ export default {
             vm.$refs.flora_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers, false); // This calls ajax() backend call.
             sessionStorage.setItem(vm.filterOCRFloraSubmittedToDate_cache, vm.filterOCRFloraSubmittedToDate);
         },
+        filterOCRFromFloraEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.flora_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRFromFloraEffectiveFromDate_cache, vm.filterOCRFromFloraEffectiveFromDate);
+        },
+        filterOCRToFloraEffectiveFromDate: function(){
+            let vm = this;
+            vm.$refs.flora_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRToFloraEffectiveFromDate_cache, vm.filterOCRToFloraEffectiveFromDate);
+        },
+        filterOCRFromFloraEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.flora_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRFromFloraEffectiveToDate_cache, vm.filterOCRFromFloraEffectiveToDate);
+        },
+        filterOCRToFloraEffectiveToDate: function(){
+            let vm = this;
+            vm.$refs.flora_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRToFloraEffectiveToDate_cache, vm.filterOCRToFloraEffectiveToDate);
+        },
+        filterOCRFromFloraDueDate: function(){
+            let vm = this;
+            vm.$refs.flora_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRFromFloraDueDate_cache, vm.filterOCRFromFloraDueDate);
+        },
+        filterOCRToFloraDueDate: function(){
+            let vm = this;
+            vm.$refs.flora_ocr_datatable.vmDataTable.ajax.reload(helpers.enablePopovers,false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterOCRToFloraDueDate_cache, vm.filterOCRToFloraDueDate);
+        },
         filterApplied: function () {
             if (this.$refs.collapsible_filters) {
                 // Collapsible component exists
@@ -228,7 +343,13 @@ export default {
                 this.filterOCRFloraScientificName === 'all' &&
                 this.filterOCRFloraStatus === 'all' &&
                 this.filterOCRFloraSubmittedFromDate === '' &&
-                this.filterOCRFloraSubmittedToDate === '') {
+                this.filterOCRFloraSubmittedToDate === '' &&
+                this.filterOCRFromFloraEffectiveFromDate === '' &&
+                this.filterOCRToFloraEffectiveFromDate === '' &&
+                this.filterOCRFromFloraEffectiveToDate === '' &&
+                this.filterOCRToFloraEffectiveToDate === '' &&
+                this.filterOCRFromFloraDueDate === '' &&
+                this.filterOCRToFloraDueDate === '') {
                 return false
             } else {
                 return true
@@ -474,6 +595,12 @@ export default {
                         d.filter_status = vm.filterOCRFloraStatus;
                         d.filter_submitted_from_date = vm.filterOCRFloraSubmittedFromDate;
                         d.filter_submitted_to_date = vm.filterOCRFloraSubmittedToDate;
+                        d.filter_from_effective_from_date = vm.filterOCRFromFloraEffectiveFromDate;
+                        d.filter_to_effective_from_date = vm.filterOCRToFloraEffectiveFromDate;
+                        d.filter_from_effective_to_date = vm.filterOCRFromFloraEffectiveToDate;
+                        d.filter_to_effective_to_date = vm.filterOCRToFloraEffectiveToDate;
+                        d.filter_from_due_date = vm.filterOCRFromFloraDueDate;
+                        d.filter_to_due_date = vm.filterOCRToFloraDueDate;
                         d.is_internal = vm.is_internal;
                     }
                 },
@@ -763,6 +890,12 @@ export default {
                 filter_status: vm.filterOCRFloraStatus,
                 filter_submitted_from_date: vm.filterOCRFloraSubmittedFromDate,
                 filter_submitted_to_date: vm.filterOCRFloraSubmittedToDate,
+                filter_from_effective_from_date: vm.filterOCRFromFloraEffectiveFromDate,
+                filter_to_effective_from_date: vm.filterOCRToFloraEffectiveFromDate,
+                filter_from_effective_to_date: vm.filterOCRFromFloraEffectiveToDate,
+                filter_to_effective_to_date: vm.filterOCRToFloraEffectiveToDate,
+                filter_from_due_date: vm.filterOCRFromFloraDueDate,
+                filter_to_due_date: vm.filterOCRToFloraDueDate,
                 is_internal: vm.is_internal,
                 export_format: format
             };

--- a/boranga/frontend/boranga/src/components/form_species_communities.vue
+++ b/boranga/frontend/boranga/src/components/form_species_communities.vue
@@ -8,7 +8,7 @@
                         Profile
                     </a>
                 </li>
-                <li class="nav-item" v-if="is_int">
+                <li class="nav-item" v-if="is_internal">
                     <a class="nav-link" id="pills-documents-tab" data-bs-toggle="pill" :href="'#' + documentBody"
                         role="tab" aria-controls="pills-documents" :aria-selected="documentBody" @click="tabClicked()">
                         Documents

--- a/boranga/frontend/boranga/src/components/internal/meetings/meetings_datatable.vue
+++ b/boranga/frontend/boranga/src/components/internal/meetings/meetings_datatable.vue
@@ -5,16 +5,30 @@
             <div class="row">
                 <div class="col-md-3">
                     <div class="form-group">
-                        <label for="">Start Date:</label>
-                        <input type="datetime-local" class="form-control" placeholder="DD/MM/YYYY" id="start_date"
-                            v-model="filterMeetingStartDate">
+                        <label for="">Start Date Range:</label>
+                        <input type="datetime-local" class="form-control" placeholder="DD/MM/YYYY" id="from_start_date"
+                            v-model="filterFromMeetingStartDate">
                     </div>
                 </div>
                 <div class="col-md-3">
                     <div class="form-group">
-                        <label for="">End Date:</label>
-                        <input type="datetime-local" class="form-control" placeholder="DD/MM/YYYY" id="end_date"
-                            v-model="filterMeetingEndDate">
+                        <label for=""></label>
+                        <input type="datetime-local" class="form-control" placeholder="DD/MM/YYYY" id="to_start_date"
+                            v-model="filterToMeetingStartDate">
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="form-group">
+                        <label for="">End Date :</label>
+                        <input type="datetime-local" class="form-control" placeholder="DD/MM/YYYY" id="from_end_date"
+                            v-model="filterFromMeetingEndDate">
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="form-group">
+                        <label for=""></label>
+                        <input type="datetime-local" class="form-control" placeholder="DD/MM/YYYY" id="to_end_date"
+                            v-model="filterToMeetingEndDate">
                     </div>
                 </div>
                 <div class="col-md-3">
@@ -62,15 +76,25 @@ export default {
             type: String,
             required: true
         },
-        filterMeetingStartDate_cache: {
+        filterFromMeetingStartDate_cache: {
             type: String,
             required: false,
-            default: 'filterMeetingStartDate',
+            default: 'filterFromMeetingStartDate',
         },
-        filterMeetingEndDate_cache: {
+        filterToMeetingStartDate_cache: {
             type: String,
             required: false,
-            default: 'filterMeetingEndDate',
+            default: 'filterToMeetingStartDate',
+        },
+        filterFromMeetingEndDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterFromMeetingEndDate',
+        },
+        filterToMeetingEndDate_cache: {
+            type: String,
+            required: false,
+            default: 'filterToMeetingEndDate',
         },
         filterMeetingStatus_cache: {
             type: String,
@@ -83,8 +107,12 @@ export default {
         return {
             datatable_id: 'meetings-datatable-' + vm._uid,
 
-            filterMeetingStartDate: sessionStorage.getItem(this.filterMeetingStartDate_cache) ? sessionStorage.getItem(this.filterMeetingStartDate_cache) : '',
-            filterMeetingEndDate: sessionStorage.getItem(this.filterMeetingEndDate_cache) ? sessionStorage.getItem(this.filterMeetingEndDate_cache) : '',
+            filterFromMeetingStartDate: sessionStorage.getItem(this.filterFromMeetingStartDate_cache) ? sessionStorage.getItem(this.filterFromMeetingStartDate_cache) : '',
+            filterToMeetingStartDate: sessionStorage.getItem(this.filterToMeetingStartDate_cache) ? sessionStorage.getItem(this.filterToMeetingStartDate_cache) : '',
+
+            filterFromMeetingEndDate: sessionStorage.getItem(this.filterFromMeetingEndDate_cache) ? sessionStorage.getItem(this.filterFromMeetingEndDate_cache) : '',
+            filterToMeetingEndDate: sessionStorage.getItem(this.filterToMeetingEndDate_cache) ? sessionStorage.getItem(this.filterToMeetingEndDate_cache) : '',
+
             filterMeetingStatus: sessionStorage.getItem(this.filterMeetingStatus_cache) ? sessionStorage.getItem(this.filterMeetingStatus_cache) : 'all',
 
             internal_status: [
@@ -101,15 +129,25 @@ export default {
         CollapsibleFilters,
     },
     watch: {
-        filterMeetingStartDate: function () {
+        filterFromMeetingStartDate: function () {
             let vm = this;
             vm.$refs.meetings_datatable.vmDataTable.ajax.reload(helpers.enablePopovers, false); // This calls ajax() backend call.
-            sessionStorage.setItem(vm.filterMeetingStartDate_cache, vm.filterMeetingStartDate);
+            sessionStorage.setItem(vm.filterFromMeetingStartDate_cache, vm.filterFromMeetingStartDate);
         },
-        filterMeetingEndDate: function () {
+        filterToMeetingStartDate: function () {
             let vm = this;
             vm.$refs.meetings_datatable.vmDataTable.ajax.reload(helpers.enablePopovers, false); // This calls ajax() backend call.
-            sessionStorage.setItem(vm.filterMeetingEndDate_cache, vm.filterMeetingEndDate);
+            sessionStorage.setItem(vm.filterToMeetingStartDate_cache, vm.filterToMeetingStartDate);
+        },
+        filterFromMeetingEndDate: function () {
+            let vm = this;
+            vm.$refs.meetings_datatable.vmDataTable.ajax.reload(helpers.enablePopovers, false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterFromMeetingEndDate_cache, vm.filterFromMeetingEndDate);
+        },
+        filterToMeetingEndDate: function () {
+            let vm = this;
+            vm.$refs.meetings_datatable.vmDataTable.ajax.reload(helpers.enablePopovers, false); // This calls ajax() backend call.
+            sessionStorage.setItem(vm.filterToMeetingEndDate_cache, vm.filterToMeetingEndDate);
         },
         filterMeetingStatus: function () {
             let vm = this;
@@ -124,8 +162,10 @@ export default {
     },
     computed: {
         filterApplied: function () {
-            if (this.filterMeetingStartDate === '' &&
-                this.filterMeetingEndDate === '' &&
+            if (this.filterFromMeetingStartDate === '' &&
+                this.filterToMeetingStartDate === '' &&
+                this.filterFromMeetingEndDate === '' &&
+                this.filterToMeetingEndDate === '' &&
                 this.filterMeetingStatus === 'all') {
                 return false
             } else {
@@ -302,8 +342,10 @@ export default {
 
                     // adding extra GET params for Custom filtering
                     "data": function (d) {
-                        d.filter_start_date = vm.filterMeetingStartDate;
-                        d.filter_end_date = vm.filterMeetingEndDate;
+                        d.filter_to_start_date = vm.filterToMeetingStartDate;
+                        d.filter_from_start_date = vm.filterFromMeetingStartDate;
+                        d.filter_to_end_date = vm.filterToMeetingEndDate;
+                        d.filter_from_end_date = vm.filterFromMeetingEndDate;
                         d.filter_meeting_status = vm.filterMeetingStatus;
                     }
                 },
@@ -461,8 +503,10 @@ export default {
 
             const object_load = {
                 columns: columns_new,
-                filter_start_date: vm.filterMeetingStartDate,
-                filter_end_date: vm.filterMeetingEndDate,
+                filter_from_start_date: vm.filterFromMeetingStartDate,
+                filter_to_start_date: vm.filterToMeetingStartDate,
+                filter_from_end_date: vm.filterFromMeetingEndDate,
+                filter_to_end_date: vm.filterToMeetingEndDate,
                 filter_meeting_status: vm.filterMeetingStatus,
                 is_internal: vm.is_internal,
                 export_format: format

--- a/boranga/frontend/boranga/src/components/internal/occurrence/occurrence.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/occurrence.vue
@@ -318,7 +318,7 @@ export default {
             await vm.save().then(() => {
                 if (vm.isSaved === true) {
                     vm.$router.push({
-                        name: 'occurrence-dashboard'
+                        name: 'internal-occurrence-dash'
                     });
                 }
                 else {
@@ -406,7 +406,7 @@ export default {
                         vm.$http.post(submit_url, payload).then(res => {
                             vm.occurrence = res.body;
                             vm.$router.push({
-                                name: 'occurrence-dashboard'
+                                name: 'internal-occurrence-dash'
                             });
                         }, err => {
                             swal.fire({
@@ -488,7 +488,7 @@ export default {
                             confirmButtonColor: '#226fbb'
                         }).then(async (swalresult) => {
                             vm.$router.push({
-                                name: 'occurrence-dashboard'
+                                name: 'internal-occurrence-dash'
                             });
                         });
                     }, err => {

--- a/boranga/frontend/boranga/src/components/internal/occurrence/occurrence_report.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/occurrence_report.vue
@@ -527,7 +527,7 @@ export default {
             await vm.save().then(() => {
                 if (vm.isSaved === true) {
                     vm.$router.push({
-                        name: 'internal-species-communities-dash'
+                        name: 'internal-occurrence-dash'
                     });
                 }
                 else {


### PR DESCRIPTION
Added/updated date filters to all use ranges as required.

Filters include:
 - Effective From date range and Effective To date range for Conservation Status
 - Start date range and End date range for Meetings
 - Effective From date range and Effective To date range for Occurrence
 - Submitted date range, Effective From date range, and Effective To date range for Occurrence Report

All date range filters feature two date inputs, with the result filter records so that the give filtered date value falls between those values. GTE and LTE operators are used for each filter pair.

Review Due date filters have also been added for OCC and OCR, however not implemented on the frontend as the tables do not present that value.

This PR also includes some minor unrelated bugs fixes, including:
 - Document tab in S&C not showing (typo bug)
 - OCR Threat Edit not working (minor serializer issue)
 - OCC Save and Exit button and Close button properly redirect to occurrence dashboard after use
