### PR TITLE
S&C prevent saving if no changes made

### DIFF
--- a/boranga/frontend/boranga/src/components/common/species_communities/community_profile.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/community_profile.vue
@@ -434,6 +434,10 @@ export default {
             type: Object,
             required: true
         },
+        species_community_original: {
+            type: Object,
+            required: true
+        },
         is_internal: {
             type: Boolean,
             default: false
@@ -571,6 +575,7 @@ export default {
             }).then((response) => {
                 vm.updatingPublishing = false;
                 vm.species_community.publishing_status = response.body;
+                vm.species_community_original.publishing_status = helpers.copyObject(vm.species_community.publishing_status);
                 swal.fire({
                     title: 'Saved',
                     text: 'Publishing settings have been updated',
@@ -594,7 +599,16 @@ export default {
             vm.updatingPublishing = true;
             //if not already public, we make it public (notify user first)
             //but only if it is active
-            if (vm.isPublic && vm.isActive) {
+            if (helpers.checkForChange(vm.species_community_original.publishing_status,vm.species_community.publishing_status)) {
+                swal.fire({
+                    title: 'Error',
+                    text: 'No changes made',
+                    icon: 'error',
+                    confirmButtonColor:'#226fbb',
+                });
+                vm.updatingPublishing = false;
+            }
+            else if (vm.isPublic && vm.isActive) {
                 //send just publishing form data
                 let data = JSON.stringify(vm.species_community.publishing_status)
                 vm.updatePublishing(data);

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_profile.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_profile.vue
@@ -733,6 +733,10 @@ export default {
             type: Object,
             required: true
         },
+        species_community_original: {
+            type: Object,
+            required: true
+        },
         // this prop is only send from split species form to make the original species readonly
         is_readonly: {
             type: Boolean,
@@ -924,6 +928,7 @@ export default {
             }).then((response) => {
                 vm.updatingPublishing = false;
                 vm.species_community.publishing_status = response.body;
+                vm.species_community_original.publishing_status = helpers.copyObject(vm.species_community.publishing_status);
                 swal.fire({
                     title: 'Saved',
                     text: 'Publishing settings have been updated',
@@ -947,7 +952,16 @@ export default {
             vm.updatingPublishing = true;
             //if not already public, we make it public (notify user first)
             //but only if it is active
-            if (vm.isPublic && vm.isActive) {
+            if (helpers.checkForChange(vm.species_community_original.publishing_status,vm.species_community.publishing_status)) {
+                swal.fire({
+                    title: 'Error',
+                    text: 'No changes made',
+                    icon: 'error',
+                    confirmButtonColor:'#226fbb',
+                });
+                vm.updatingPublishing = false;
+            }
+            else if (vm.isPublic && vm.isActive) {
                 //send just publishing form data
                 let data = JSON.stringify(vm.species_community.publishing_status)
                 vm.updatePublishing(data);

--- a/boranga/frontend/boranga/src/components/form_species_communities.vue
+++ b/boranga/frontend/boranga/src/components/form_species_communities.vue
@@ -31,10 +31,10 @@
                 <div v-if="is_internal || is_public" class="tab-pane fade show active" :id="profileBody" role="tabpanel"
                     aria-labelledby="pills-profile-tab">
                     <Community v-if="isCommunity" ref="community_information" id="communityInformation"
-                        :is_internal="is_internal" :species_community="species_community">
+                        :is_internal="is_internal" :species_community="species_community" :species_community_original="species_community_original">
                     </Community>
                     <Species v-else ref="species_information" id="speciesInformation" :is_internal="is_internal"
-                        :species_community="species_community" :is_readonly="is_readonly"
+                        :species_community="species_community" :species_community_original="species_community_original" :is_readonly="is_readonly"
                         :rename_species="rename_species">
                     </Species>
                 </div>
@@ -80,6 +80,10 @@ import RelatedItems from '@/components/common/table_related_items.vue'
 export default {
     props: {
         species_community: {
+            type: Object,
+            required: true
+        },
+        species_community_original: {
             type: Object,
             required: true
         },

--- a/boranga/frontend/boranga/src/components/internal/species_communities/make_public.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/make_public.vue
@@ -79,6 +79,10 @@ export default {
             type: Object,
             required: true
         },
+        species_community_original: {
+            type: Object,
+            required: true
+        },
         is_internal: {
             type: Boolean,
             required: true
@@ -136,6 +140,7 @@ export default {
             }).then((response) => {
                 vm.updatingPublishing = false;
                 vm.species_community.publishing_status = response.body;
+                vm.species_community_original.publishing_status = helpers.copyObject(vm.species_community.publishing_status);
                 swal.fire({
                     title: 'Saved',
                     text: 'Record has been made public',
@@ -152,6 +157,7 @@ export default {
                     icon: 'error',
                     confirmButtonColor:'#226fbb',
                 });
+                vm.species_community.publishing_status = helpers.copyObject(vm.species_community_original.publishing_status);
                 vm.updatingPublishing = false;
             });
         },

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
@@ -564,8 +564,17 @@ export default {
         can_submit: function (check_action) {
             let vm = this;
 
-            if (check_action != 'submit' && helpers.checkForChange(vm.species_community_original,vm.species_community)) {
-                return ["No changes made"]
+            if (check_action != 'submit') {
+                //remove publishing status for check as it is handled separately
+                let sc_no_ps = helpers.copyObject(vm.species_community);
+                let sco_no_ps = helpers.copyObject(vm.species_community_original);
+                
+                sc_no_ps.publishing_status = undefined;
+                sco_no_ps.publishing_status = undefined;
+
+                if (helpers.checkForChange(sco_no_ps,sc_no_ps)) {
+                    return ["No changes made"]
+                }
             }
 
             let blank_fields = []

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
@@ -116,7 +116,7 @@
                                 <form :action="species_community_form_url" method="post" name="new_species"
                                     enctype="multipart/form-data">
                                     <ProposalSpeciesCommunities ref="species_communities"
-                                        :species_community="species_community" id="speciesCommunityStart"
+                                        :species_community="species_community" :species_community_original="species_community_original" id="speciesCommunityStart"
                                         :is_internal="true" :is_readonly="species_community.readonly">
                                     </ProposalSpeciesCommunities>
                                     <input type="hidden" name="csrfmiddlewaretoken" :value="csrf_token" />
@@ -178,8 +178,8 @@
             @refreshFromResponse="refreshFromResponse" />
         <SpeciesRename ref="species_rename" :species_community_original="species_community" :is_internal="true"
             @refreshFromResponse="refreshFromResponse" />
-        <MakePublic ref="make_public" :species_community="species_community" :is_internal="true"
-            @refreshFromResponse="refreshFromResponse" />
+        <MakePublic ref="make_public" :species_community="species_community" :species_community_original="species_community_original" 
+            :is_internal="true" @refreshFromResponse="refreshFromResponse" />
     </div>
 </template>
 <script>
@@ -204,6 +204,7 @@ export default {
         let vm = this;
         return {
             "species_community": null,
+            "species_community_original": null,
             form: null,
             savingSpeciesCommunity: false,
             saveExitSpeciesCommunity: false,
@@ -490,6 +491,7 @@ export default {
 
             await vm.$http.post(vm.species_community_form_url, payload).then(res => {
                 vm.species_community = res.body;
+                vm.species_community_original = helpers.copyObject(vm.species_community); //update original after save
                 swal.fire({
                     title: "Saved",
                     text: "Your changes has been saved" + was_public,
@@ -561,6 +563,11 @@ export default {
         },
         can_submit: function (check_action) {
             let vm = this;
+
+            if (check_action != 'submit' && helpers.checkForChange(vm.species_community_original,vm.species_community)) {
+                return ["No changes made"]
+            }
+
             let blank_fields = []
             if (vm.species_community.group_type == 'flora' || vm.species_community.group_type == 'fauna') {
                 if (vm.species_community.taxonomy_id == null || vm.species_community.taxonomy_id == '') {
@@ -616,6 +623,7 @@ export default {
                             helpers.add_endpoint_json(api_endpoints.species, vm.species_community.id + '/submit')
                         vm.$http.post(submit_url, payload).then(res => {
                             vm.species_community = res.body;
+                            vm.species_community_original = helpers.copyObject(vm.species_community);
                             // vm.$router.push({
                             //     name: 'submit_cs_proposal',
                             //     params: { conservation_status_obj: vm.conservation_status_obj}
@@ -647,8 +655,8 @@ export default {
         },
         refreshFromResponse: function (response) {
             let vm = this;
-            vm.original_species_community = helpers.copyObject(response.body);
             vm.species_community = helpers.copyObject(response.body);
+            vm.species_community_original = copyObject(vm.species_community);
         },
         splitSpecies: async function () {
             this.$refs.species_split.species_community_original = this.species_community;
@@ -767,6 +775,7 @@ export default {
             }).then((response) => {
                 vm.updatingPublishing = false;
                 vm.species_community.publishing_status = response.body;
+                vm.species_community_original.publishing_status = helpers.copyObject(vm.species_community.publishing_status);
                 swal.fire({
                     title: 'Saved',
                     text: 'Record has been made private',
@@ -801,6 +810,7 @@ export default {
             Vue.http.get(`/api/species/${to.params.species_community_id}/internal_species.json`).then(res => {
                 next(vm => {
                     vm.species_community = res.body.species_obj; //--temp species_obj
+                    vm.species_community_original = helpers.copyObject(vm.species_community);
                     vm.uploadedID = vm.species_community.image_doc;
                 });
             },
@@ -813,6 +823,7 @@ export default {
             Vue.http.get(`/api/community/${to.params.species_community_id}/internal_community.json`).then(res => {
                 next(vm => {
                     vm.species_community = res.body.community_obj; //--temp community_obj
+                    vm.species_community_original = helpers.copyObject(vm.species_community);
                     vm.uploadedID = vm.species_community.image_doc;
                 });
             },

--- a/boranga/frontend/boranga/src/utils/helpers.js
+++ b/boranga/frontend/boranga/src/utils/helpers.js
@@ -244,4 +244,13 @@ module.exports = {
  //         })
  //       })
  //   },
+
+    checkForChange: function(before, after) {
+        //compare two objects, return true if the are the same
+        console.log(before);
+        console.log(after);
+        //JSON.stringify does not guarantee order and removes keys with undefined values
+        //that is acceptable for this use case, however
+        return JSON.stringify(before) === JSON.stringify(after);
+    }
 };


### PR DESCRIPTION
When an S&C record is saved it makes the record private if it was public. To prevent accidental saves, a check is in place to ensure a change has been made before continuing to save.

If no change has been made, a dialogue appears informing the user that no changes have been made.

It works by maintaining a copy of the original S&C object, which itself is only updated after a successful save/refresh, and comparing the main S&C object to it before submission. The compare function has been included as a helper function.

Publishing status for an S&C record is handled by its own endpoint so has its own change check as well, and removed from the main S&C objects when they are validated (using copies so as not to alter the actual objects).

Currently exclusively applied for S&C on the client-side. May be useful to apply to other models and potentially enforce server-side as well.