### PR TITLE
Minor Changes

### DIFF
--- a/boranga/components/occurrence/api.py
+++ b/boranga/components/occurrence/api.py
@@ -2696,7 +2696,7 @@ class OccurrenceDocumentViewSet(viewsets.ModelViewSet):
 
     def is_authorised_to_update(self, occurrence):
         user = self.request.user
-        if not (user.id in occurrence.get_occurrence_editor_group().get_system_group_member_ids()):
+        if not (user.id in occurrence.get_occurrence_approver_group().get_system_group_member_ids()):
             raise serializers.ValidationError("User not authorised to update Occurrence")
 
     @detail_route(
@@ -2851,7 +2851,7 @@ class OCCConservationThreatViewSet(viewsets.ModelViewSet):
 
     def is_authorised_to_update(self, occurrence):
         user = self.request.user
-        if not (user.id in occurrence.get_occurrence_editor_group().get_system_group_member_ids()):
+        if not (user.id in occurrence.get_occurrence_approver_group().get_system_group_member_ids()):
             raise serializers.ValidationError("User not authorised to update Occurrence")
 
     @detail_route(
@@ -2984,7 +2984,7 @@ class OccurrenceViewSet(UserActionLoggingViewset, DatumSearchMixing):
     def is_authorised_to_update(self):
         user = self.request.user
         instance = self.get_object()
-        if not (user.id in instance.get_occurrence_editor_group().get_system_group_member_ids() and instance.processing_status == Occurrence.PROCESSING_STATUS_ACTIVE):
+        if not (user.id in instance.get_occurrence_approver_group().get_system_group_member_ids() and instance.processing_status == Occurrence.PROCESSING_STATUS_ACTIVE):
             raise serializers.ValidationError("User not authorised to update Occurrence")
 
     @transaction.atomic
@@ -2997,7 +2997,7 @@ class OccurrenceViewSet(UserActionLoggingViewset, DatumSearchMixing):
             group_type=group_type_id,
         )
 
-        if not (request.user.id in new_instance.get_occurrence_editor_group().get_system_group_member_ids()):
+        if not (request.user.id in new_instance.get_occurrence_approver_group().get_system_group_member_ids()):
             raise serializers.ValidationError("User not authorised to create Occurrence")
 
         new_instance.save(version_user=request.user)
@@ -3074,7 +3074,7 @@ class OccurrenceViewSet(UserActionLoggingViewset, DatumSearchMixing):
     def unlock_occurrence(self, request, *args, **kwargs):
         user = request.user
         instance = self.get_object()
-        if not (user.id in instance.get_occurrence_editor_group().get_system_group_member_ids() and instance.processing_status == Occurrence.PROCESSING_STATUS_LOCKED):
+        if not (user.id in instance.get_occurrence_approver_group().get_system_group_member_ids() and instance.processing_status == Occurrence.PROCESSING_STATUS_LOCKED):
             raise serializers.ValidationError("User not authorised to update Occurrence")
         instance.processing_status = Occurrence.PROCESSING_STATUS_ACTIVE
         instance.save(version_user=user)

--- a/boranga/components/occurrence/models.py
+++ b/boranga/components/occurrence/models.py
@@ -2681,10 +2681,10 @@ class Occurrence(RevisionedMixin):
         else:
             return (
                 user.id
-                in self.get_occurrence_editor_group().get_system_group_member_ids()
+                in self.get_occurrence_approver_group().get_system_group_member_ids()
             )
 
-    def get_occurrence_editor_group(self):
+    def get_occurrence_approver_group(self):
         return SystemGroup.objects.get(name=GROUP_NAME_OCCURRENCE_APPROVER)
 
     def log_user_action(self, action, request):

--- a/boranga/components/species_and_communities/utils.py
+++ b/boranga/components/species_and_communities/utils.py
@@ -57,7 +57,8 @@ def species_form_submit(species_instance, request):
     if (settings.WORKING_FROM_HOME and settings.DEBUG) or ret1 and ret2:
         species_instance.processing_status = Species.PROCESSING_STATUS_ACTIVE
         species_instance.species_documents.all().update(can_delete=False)
-        species_instance.save()
+        #all functions that call this save after - otherwise we can parametise this if need be
+        species_instance.save(no_revision=True)
     else:
         raise ValidationError(
             "An error occurred while submitting proposal (Submit email notifications failed)"
@@ -97,7 +98,7 @@ def community_form_submit(community_instance, request):
     if (settings.WORKING_FROM_HOME and settings.DEBUG) or ret1 and ret2:
         community_instance.processing_status = Community.PROCESSING_STATUS_ACTIVE
         community_instance.community_documents.all().update(can_delete=False)
-        community_instance.save()
+        community_instance.save(no_revision=True)
     else:
         raise ValidationError(
             "An error occurred while submitting proposal (Submit email notifications failed)"
@@ -142,7 +143,7 @@ def combine_species_original_submit(species_instance, request):
 def rename_species_original_submit(species_instance, request):
     if species_instance.processing_status == "active":
         species_instance.processing_status = "historical"
-        species_instance.save()
+        species_instance.save(version_user=request.user)
         #  send the rename species email notification
         send_species_rename_email_notification(request, species_instance)
 
@@ -155,7 +156,7 @@ def rename_species_original_submit(species_instance, request):
                 if species_cons_status:
                     species_cons_status.customer_status = "closed"
                     species_cons_status.processing_status = "closed"
-                    species_cons_status.save()
+                    species_cons_status.save(version_user=request.user)
                     # add the log_user_action
                     species_cons_status.log_user_action(
                         ConservationStatusUserAction.ACTION_CLOSE_CONSERVATIONSTATUS.format(

--- a/boranga/frontend/boranga/src/components/internal/conservation_status/community_conservation_status_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/conservation_status/community_conservation_status_history.vue
@@ -446,10 +446,18 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>

--- a/boranga/frontend/boranga/src/components/internal/conservation_status/cs_document_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/conservation_status/cs_document_history.vue
@@ -370,11 +370,19 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/conservation_status/species_conservation_status_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/conservation_status/species_conservation_status_history.vue
@@ -454,10 +454,18 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>

--- a/boranga/frontend/boranga/src/components/internal/meetings/minutes_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/meetings/minutes_history.vue
@@ -359,7 +359,15 @@ export default {
             this.$nextTick(() => {
                 vm.addEventListeners();
             });
-        },
+    },
+    watch: {
+        isModalOpen() {
+            let vm = this;
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/occurrence/community_occurrence_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/community_occurrence_history.vue
@@ -438,10 +438,18 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>

--- a/boranga/frontend/boranga/src/components/internal/occurrence/community_occurrence_report_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/community_occurrence_report_history.vue
@@ -396,10 +396,18 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>

--- a/boranga/frontend/boranga/src/components/internal/occurrence/occ_conservation_threat_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/occ_conservation_threat_history.vue
@@ -317,11 +317,19 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/occurrence/occ_document_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/occ_document_history.vue
@@ -369,11 +369,19 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/occurrence/ocr_conservation_threat_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/ocr_conservation_threat_history.vue
@@ -317,11 +317,19 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/occurrence/ocr_document_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/ocr_document_history.vue
@@ -369,11 +369,19 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/occurrence/species_occurrence_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/species_occurrence_history.vue
@@ -462,10 +462,18 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>

--- a/boranga/frontend/boranga/src/components/internal/occurrence/species_occurrence_report_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/species_occurrence_report_history.vue
@@ -420,10 +420,18 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>

--- a/boranga/frontend/boranga/src/components/internal/species_communities/community_document_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/community_document_history.vue
@@ -370,11 +370,19 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/species_communities/community_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/community_history.vue
@@ -404,10 +404,18 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>

--- a/boranga/frontend/boranga/src/components/internal/species_communities/conservation_threat_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/conservation_threat_history.vue
@@ -317,11 +317,19 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
@@ -542,6 +542,11 @@ export default {
             let vm = this;
             vm.saveError = false;
 
+            //only save if something has changed
+            if (vm.can_submit("") != true) {
+                return false;
+            }
+
             let payload = new Object();
             Object.assign(payload, vm.species_community);
             const result = await vm.$http.post(vm.species_community_form_url, payload).then(res => {

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_document_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_document_history.vue
@@ -370,11 +370,19 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_history.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_history.vue
@@ -411,10 +411,18 @@ export default {
         }
     },
     mounted: function(){
+        let vm = this;
+        this.$nextTick(() => {
+            vm.addEventListeners();
+        });
+    },
+    watch: {
+        isModalOpen() {
             let vm = this;
-            this.$nextTick(() => {
-                vm.addEventListeners();
-            });
-        },
+            if (this.isModalOpen) {
+                vm.$refs.history_datatable.vmDataTable.ajax.reload();
+            }
+        }
+    },
 };
 </script>


### PR DESCRIPTION
Minor changes to address some test findings:

 - Submitting a species will no longer produce three history records, instead it will produce two if a change had been made (save before submit) or only one
 - History tables will now reload when their containing modal is opened
 - renamed get_occurrence_editor_group to get_occurrence_approver_group