### PR TITLE
Viewset Mixin Change

### DIFF
--- a/boranga/components/conservation_status/api.py
+++ b/boranga/components/conservation_status/api.py
@@ -12,7 +12,7 @@ from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 from openpyxl import Workbook
 from openpyxl.styles import Font
 from openpyxl.utils.dataframe import dataframe_to_rows
-from rest_framework import serializers, views, viewsets
+from rest_framework import serializers, views, viewsets, mixins
 from rest_framework.decorators import action as detail_route
 from rest_framework.decorators import action as list_route
 from rest_framework.decorators import renderer_classes
@@ -431,7 +431,7 @@ class SpeciesConservationStatusFilterBackend(DatatablesFilterBackend):
         return queryset
 
 
-class SpeciesConservationStatusPaginatedViewSet(viewsets.ModelViewSet):
+class SpeciesConservationStatusPaginatedViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (SpeciesConservationStatusFilterBackend,)
     pagination_class = DatatablesPageNumberPagination
     queryset = ConservationStatus.objects.none()
@@ -902,7 +902,7 @@ class CommunityConservationStatusFilterBackend(DatatablesFilterBackend):
         return queryset
 
 
-class CommunityConservationStatusPaginatedViewSet(viewsets.ModelViewSet):
+class CommunityConservationStatusPaginatedViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (CommunityConservationStatusFilterBackend,)
     pagination_class = DatatablesPageNumberPagination
     # renderer_classes = (CommunityConservationStatusRenderer,)
@@ -1262,7 +1262,7 @@ class ConservationStatusFilterBackend(DatatablesFilterBackend):
         return queryset
 
 
-class ConservationStatusPaginatedViewSet(viewsets.ModelViewSet):
+class ConservationStatusPaginatedViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (ConservationStatusFilterBackend,)
     pagination_class = DatatablesPageNumberPagination
     queryset = ConservationStatus.objects.none()
@@ -1301,7 +1301,7 @@ class ConservationStatusPaginatedViewSet(viewsets.ModelViewSet):
         return self.paginator.get_paginated_response(serializer.data)
 
 
-class ConservationStatusViewSet(viewsets.ModelViewSet):
+class ConservationStatusViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = ConservationStatus.objects.none()
     serializer_class = ConservationStatusSerializer
     lookup_field = "id"
@@ -1752,7 +1752,7 @@ class ConservationStatusViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class ConservationStatusReferralViewSet(viewsets.ModelViewSet):
+class ConservationStatusReferralViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     # queryset = Referral.objects.all()
     queryset = ConservationStatusReferral.objects.none()
     serializer_class = ConservationStatusReferralSerializer
@@ -2135,7 +2135,7 @@ class ConservationStatusReferralViewSet(viewsets.ModelViewSet):
         return redirect(reverse("internal"))
 
 
-class ConservationStatusAmendmentRequestViewSet(viewsets.ModelViewSet):
+class ConservationStatusAmendmentRequestViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = ConservationStatusAmendmentRequest.objects.none()
     serializer_class = ConservationStatusAmendmentRequestSerializer
 
@@ -2174,7 +2174,7 @@ class ConservationStatusAmendmentRequestViewSet(viewsets.ModelViewSet):
         )
 
 
-class ConservationStatusDocumentViewSet(viewsets.ModelViewSet):
+class ConservationStatusDocumentViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = ConservationStatusDocument.objects.none()
     serializer_class = ConservationStatusDocumentSerializer
 

--- a/boranga/components/meetings/api.py
+++ b/boranga/components/meetings/api.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from openpyxl import Workbook
 from openpyxl.styles import Font
 from openpyxl.utils.dataframe import dataframe_to_rows
-from rest_framework import views, viewsets
+from rest_framework import views, viewsets, mixins
 from rest_framework.decorators import action as detail_route
 from rest_framework.decorators import action as list_route
 from rest_framework.decorators import renderer_classes
@@ -208,7 +208,7 @@ class MeetingPaginatedViewSet(viewsets.ReadOnlyModelViewSet):
                 return Response(status=400, data="Format not valid")
 
 
-class MeetingViewSet(UserActionLoggingViewset):
+class MeetingViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = Meeting.objects.none()
     serializer_class = MeetingSerializer
 
@@ -514,7 +514,7 @@ class GetMeetingDict(views.APIView):
         return HttpResponse(res_json, content_type="application/json")
 
 
-class MinutesViewSet(viewsets.ModelViewSet):
+class MinutesViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = Minutes.objects.none()
     serializer_class = MinutesSerializer
 
@@ -592,7 +592,8 @@ class MinutesViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class CommitteeViewSet(viewsets.ModelViewSet):
+#TODO: review - what is this used for and how should it work? Right now selecting a committee does not appear to have any persistent effect
+class CommitteeViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = Committee.objects.none()
     serializer_class = None
 
@@ -619,7 +620,7 @@ class CommitteeViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class AgendaItemViewSet(viewsets.ModelViewSet):
+class AgendaItemViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = AgendaItem.objects.none()
     serializer_class = AgendaItemSerializer
 

--- a/boranga/components/occurrence/api.py
+++ b/boranga/components/occurrence/api.py
@@ -14,7 +14,7 @@ from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 from openpyxl import Workbook
 from openpyxl.styles import Font
 from openpyxl.utils.dataframe import dataframe_to_rows
-from rest_framework import serializers, views, viewsets
+from rest_framework import serializers, views, viewsets, mixins
 from rest_framework.decorators import action as detail_route
 from rest_framework.decorators import action as list_route
 from rest_framework.decorators import renderer_classes
@@ -295,7 +295,7 @@ class OccurrenceReportFilterBackend(DatatablesFilterBackend):
 #         return super(OccurrenceReportRenderer, self).render(data, accepted_media_type, renderer_context)
 
 
-class OccurrenceReportPaginatedViewSet(viewsets.ModelViewSet):
+class OccurrenceReportPaginatedViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (OccurrenceReportFilterBackend,)
     pagination_class = DatatablesPageNumberPagination
     queryset = OccurrenceReport.objects.none()
@@ -647,7 +647,7 @@ class OccurrenceReportPaginatedViewSet(viewsets.ModelViewSet):
                 return Response(status=400, data="Format not valid")
 
 
-class OccurrenceReportViewSet(UserActionLoggingViewset, DatumSearchMixing):
+class OccurrenceReportViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = OccurrenceReport.objects.none()
     serializer_class = OccurrenceReportSerializer
     lookup_field = "id"
@@ -2003,7 +2003,7 @@ class OccurrenceReportViewSet(UserActionLoggingViewset, DatumSearchMixing):
         return Response(serializer.data)
 
 
-class ObserverDetailViewSet(viewsets.ModelViewSet):
+class ObserverDetailViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = OCRObserverDetail.objects.none()
     serializer_class = OCRObserverDetailSerializer
 
@@ -2096,7 +2096,7 @@ class ObserverDetailViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class OccurrenceReportAmendmentRequestViewSet(viewsets.ModelViewSet):
+class OccurrenceReportAmendmentRequestViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = OccurrenceReportAmendmentRequest.objects.none()
     serializer_class = OccurrenceReportAmendmentRequestSerializer
 
@@ -2145,7 +2145,7 @@ class OccurrenceReportAmendmentRequestViewSet(viewsets.ModelViewSet):
         )
 
 
-class OccurrenceReportDocumentViewSet(viewsets.ModelViewSet):
+class OccurrenceReportDocumentViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = OccurrenceReportDocument.objects.none()
     serializer_class = OccurrenceReportDocumentSerializer
 
@@ -2317,7 +2317,7 @@ class OCRConservationThreatFilterBackend(DatatablesFilterBackend):
         return queryset
 
 
-class OCRConservationThreatViewSet(viewsets.ModelViewSet):
+class OCRConservationThreatViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = OCRConservationThreat.objects.none()
     serializer_class = OCRConservationThreatSerializer
 
@@ -2579,7 +2579,7 @@ class OccurrenceFilterBackend(DatatablesFilterBackend):
         return queryset
 
 
-class OccurrencePaginatedViewSet(UserActionLoggingViewset):
+class OccurrencePaginatedViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = DatatablesPageNumberPagination
     queryset = Occurrence.objects.none()
     serializer_class = OccurrenceSerializer
@@ -2886,7 +2886,7 @@ class OccurrencePaginatedViewSet(UserActionLoggingViewset):
         return HttpResponse(res_json, content_type="application/json")
 
 
-class OccurrenceDocumentViewSet(viewsets.ModelViewSet):
+class OccurrenceDocumentViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = OccurrenceDocument.objects.none()
     serializer_class = OccurrenceDocumentSerializer
 
@@ -3040,7 +3040,7 @@ class OCCConservationThreatFilterBackend(DatatablesFilterBackend):
         setattr(view, "_datatables_total_count", total_count)
         return queryset
 
-class OCCConservationThreatViewSet(viewsets.ModelViewSet):
+class OCCConservationThreatViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = OCCConservationThreat.objects.none()
     serializer_class = OCCConservationThreatSerializer
     filter_backends = (OCCConservationThreatFilterBackend,)
@@ -3174,7 +3174,7 @@ class GetOccurrenceSource(views.APIView):
         return Response()
 
 
-class OccurrenceViewSet(UserActionLoggingViewset, DatumSearchMixing):
+class OccurrenceViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = Occurrence.objects.none()
     serializer_class = OccurrenceSerializer
     lookup_field = "id"
@@ -4102,7 +4102,7 @@ class OccurrenceViewSet(UserActionLoggingViewset, DatumSearchMixing):
         return HttpResponse(res_json, content_type="application/json")
 
 
-class OccurrenceReportReferralViewSet(viewsets.ModelViewSet):
+class OccurrenceReportReferralViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = OccurrenceReportReferral.objects.all()
     serializer_class = OccurrenceReportReferralSerializer
 

--- a/boranga/components/spatial/api.py
+++ b/boranga/components/spatial/api.py
@@ -8,7 +8,7 @@ from boranga.components.spatial.serializers import TileLayerSerializer
 from boranga.helpers import is_customer, is_internal
 
 
-class TileLayerViewSet(viewsets.ModelViewSet):
+class TileLayerViewSet(viewsets.ReadOnlyModelViewSet):
     """
     A simple ModelViewSet for listing or retrieving tile layers.
     """

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -15,7 +15,7 @@ from django.urls import reverse
 from openpyxl import Workbook
 from openpyxl.styles import Font
 from openpyxl.utils.dataframe import dataframe_to_rows
-from rest_framework import status, views, viewsets
+from rest_framework import status, views, viewsets, mixins
 from rest_framework.decorators import action as detail_route
 from rest_framework.decorators import action as list_route
 from rest_framework.decorators import renderer_classes
@@ -653,7 +653,7 @@ class GetDocumentCategoriesDict(views.APIView):
 
 
 # Not used now on SpeciesProfile
-class TaxonomyViewSet(viewsets.ModelViewSet):
+class TaxonomyViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Taxonomy.objects.none()
     serializer_class = TaxonomySerializer
 
@@ -749,7 +749,7 @@ class GetSpeciesProfileDict(views.APIView):
 
 
 # Not used now on CommunityProfile
-class CommunityTaxonomyViewSet(viewsets.ModelViewSet):
+class CommunityTaxonomyViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = CommunityTaxonomy.objects.none()
     serializer_class = CommunityTaxonomySerializer
 
@@ -1315,7 +1315,7 @@ class ExternalSpeciesViewSet(viewsets.ReadOnlyModelViewSet):
         )
         return Response(serializer.data)
 
-class SpeciesViewSet(viewsets.ModelViewSet):
+class SpeciesViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = Species.objects.none()
     serializer_class = InternalSpeciesSerializer
     lookup_field = "id"
@@ -1934,7 +1934,7 @@ class SpeciesViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class CommunityViewSet(viewsets.ModelViewSet):
+class CommunityViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = Community.objects.none()
     serializer_class = InternalCommunitySerializer
     lookup_field = "id"
@@ -2307,7 +2307,7 @@ class CommunityViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class SpeciesDocumentViewSet(viewsets.ModelViewSet):
+class SpeciesDocumentViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = SpeciesDocument.objects.none()
     serializer_class = SpeciesDocumentSerializer
 
@@ -2389,7 +2389,7 @@ class SpeciesDocumentViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class CommunityDocumentViewSet(viewsets.ModelViewSet):
+class CommunityDocumentViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = CommunityDocument.objects.none()
     serializer_class = CommunityDocumentSerializer
 
@@ -2526,7 +2526,7 @@ class ConservationThreatFilterBackend(DatatablesFilterBackend):
         return queryset
 
 
-class ConservationThreatViewSet(viewsets.ModelViewSet):
+class ConservationThreatViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = ConservationThreat.objects.none()
     serializer_class = ConservationThreatSerializer
     filter_backends = (ConservationThreatFilterBackend,)

--- a/boranga/components/users/api.py
+++ b/boranga/components/users/api.py
@@ -9,7 +9,7 @@ from django.db.models.functions import Concat
 from django_countries import countries
 from ledger_api_client.ledger_models import Address
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
-from rest_framework import filters, generics, serializers, views, viewsets
+from rest_framework import filters, generics, serializers, views, viewsets, mixins
 from rest_framework.decorators import action as detail_route
 from rest_framework.decorators import action as list_route
 from rest_framework.decorators import renderer_classes
@@ -75,13 +75,15 @@ class GetProfile(views.APIView):
 class UserListFilterView(generics.ListAPIView):
     """https://cop-internal.dbca.wa.gov.au/api/filtered_users?search=russell"""
 
-    queryset = EmailUser.objects.all()
+    permission_classes = [IsAssessor | IsApprover]
+
+    queryset = EmailUser.objects.none()
     serializer_class = UserFilterSerializer
     filter_backends = (filters.SearchFilter,)
     search_fields = ("email", "first_name", "last_name")
 
 
-class UserViewSet(viewsets.ModelViewSet):
+class UserViewSet(viewsets.GenericViewSet,mixins.RetrieveModelMixin):
     queryset = EmailUser.objects.all()
     serializer_class = UserSerializer
     # Add permission groups that can access the userviewset, can add more group later as required

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_profile.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_profile.vue
@@ -861,7 +861,7 @@ export default {
         },
         isNOOReadOnly: function () {
             let vm = this;
-            if (vm.species_community.distribution.noo_auto === true && vm.distribtion_public) {
+            if (vm.species_community.distribution.noo_auto === true) {
                 return true;
             }
             else {

--- a/boranga/frontend/boranga/src/components/internal/meetings/cs_queue.vue
+++ b/boranga/frontend/boranga/src/components/internal/meetings/cs_queue.vue
@@ -1,7 +1,7 @@
 <template lang="html">
     <div id="cs_queue">
         <FormSection :formCollapse="false" label="Queue" :Index="csQueueBody">
-            <div v-if="meeting_obj.user_can_edit" class="col-sm-12">
+            <div v-if="meeting_obj.can_user_edit" class="col-sm-12">
                 <div class="text-end">
                     <button :disabled="isReadOnly" type="button" class="btn btn-primary mb-2 "
                         @click.prevent="addConservationStatus">

--- a/boranga/frontend/boranga/src/components/internal/meetings/minutes.vue
+++ b/boranga/frontend/boranga/src/components/internal/meetings/minutes.vue
@@ -2,7 +2,7 @@
     <div id="minutes">
         <FormSection :formCollapse="false" label="Minutes" :Index="minutesBody">
             <form class="form-horizontal" action="index.html" method="post">
-                <div v-if="meeting_obj.user_can_edit" class="col-sm-12">
+                <div v-if="meeting_obj.can_user_edit" class="col-sm-12">
                     <div class="text-end">
                         <button type="button" class="btn btn-primary mb-2 " @click.prevent="newDocument">
                             <i class="fa-solid fa-circle-plus"></i>


### PR DESCRIPTION
A number of our API Viewset classes were inheriting the ModelViewSet class. The ModelViewSet includes handling for delete requests, among other things, that were not being properly handled by our own auth mechanisms beyond minimal queryset constraints and any applied permission_classes (the latter not yet implemented across the project).

This would essentially mean that (in most cases) any internal user could delete (and potentially alter) a record outside of any intended workflow and even when not part of an appropriate system group. 

This PR has adjusted the inheritance of all relevant classes to only use the super classes and/or mixins necessary for their intended functions. Most workflow, create, and update functions are handled directly in the pertaining class, so now most ViewSet classes either utilise (viewsets.GenericViewSet,mixins.RetrieveModelMixin) or (viewsets.ReadOnlyModelViewSet) - the latter used for our paginated viewsets.

Each endpoint and view has been tested to ensure no existing functionality has been affected and that everything still works as intended. The ability to delete records via these endpoints has also been reviewed - having been removed in all cases as appropriate.

Some accompanying adjustments include:
 - Minor frontend fixes to issues found during testing
 - The application of permission_classes to UserListFilterView (until now, unauth'ed users could use that endpoint)
 
 
