### PR TITLE
Threat Adjustments

### DIFF
--- a/boranga/components/occurrence/api.py
+++ b/boranga/components/occurrence/api.py
@@ -2289,6 +2289,18 @@ class OCRConservationThreatFilterBackend(DatatablesFilterBackend):
         if filter_threat_potential_impact and not filter_threat_potential_impact.lower() == "all":
             queryset = queryset.filter(potential_impact=filter_threat_potential_impact)
 
+        filter_threat_status = request.GET.get(
+            "filter_threat_status"
+        )
+        if (
+            filter_threat_status
+            and not filter_threat_status.lower() == "all"
+        ):
+            if filter_threat_status == "active":
+                queryset = queryset.filter(visible=True)
+            elif filter_threat_status == "removed":
+                queryset = queryset.filter(visible=False)
+
         def get_date(filter_date):
             date = request.GET.get(filter_date)
             if date:
@@ -3012,6 +3024,18 @@ class OCCConservationThreatFilterBackend(DatatablesFilterBackend):
         filter_threat_potential_impact = request.GET.get("filter_threat_potential_impact")
         if filter_threat_potential_impact and not filter_threat_potential_impact.lower() == "all":
             queryset = queryset.filter(potential_impact=filter_threat_potential_impact)
+
+        filter_threat_status = request.GET.get(
+            "filter_threat_status"
+        )
+        if (
+            filter_threat_status
+            and not filter_threat_status.lower() == "all"
+        ):
+            if filter_threat_status == "active":
+                queryset = queryset.filter(visible=True)
+            elif filter_threat_status == "removed":
+                queryset = queryset.filter(visible=False)
 
         def get_date(filter_date):
             date = request.GET.get(filter_date)

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -2498,6 +2498,18 @@ class ConservationThreatFilterBackend(DatatablesFilterBackend):
         ):
             queryset = queryset.filter(potential_impact=filter_threat_potential_impact)
 
+        filter_threat_status = request.GET.get(
+            "filter_threat_status"
+        )
+        if (
+            filter_threat_status
+            and not filter_threat_status.lower() == "all"
+        ):
+            if filter_threat_status == "active":
+                queryset = queryset.filter(visible=True)
+            elif filter_threat_status == "removed":
+                queryset = queryset.filter(visible=False)
+
         def get_date(filter_date):
             date = request.GET.get(filter_date)
             if date:

--- a/boranga/frontend/boranga/src/components/common/occurrence/occ_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occ_threats.vue
@@ -45,6 +45,16 @@
                     </div>
                     <div class="col-md-3">
                         <div class="form-group">
+                            <label for="">Status:</label>
+                            <select class="form-select" v-model="filterThreatStatus">
+                                <option value="all">All</option>
+                                <option v-for="option in threat_status_filter_list" :value="option.id">{{option.name}}
+                                </option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div class="form-group">
                             <label for="">Date Observed From:</label>
                             <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="observed_from_date" v-model="filterObservedFromDate">
                         </div>
@@ -134,6 +144,7 @@ export default {
                 filterThreatCategory: 'all',
                 filterThreatCurrentImpact: 'all',
                 filterThreatPotentialImpact: 'all',
+                filterThreatStatus: 'all',
                 filterObservedFromDate: '',
                 filterObservedToDate: '',
 
@@ -141,6 +152,11 @@ export default {
                 threat_category_filter_list: [],
                 threat_current_impact_filter_list: [],
                 threat_potential_impact_filter_list: [],
+
+                threat_status_filter_list: [
+                    {id:"active",name:"Active"},
+                    {id:"removed",name:"Removed"},
+                ],
 
                 threats_headers:['Number', 'Original Report','Category','Date Observed', 'Threat Agent', 'Comments', 'Threat Source',
                                 'Current Impact', 'Potential Impact','Action'],
@@ -165,6 +181,7 @@ export default {
                             d.filter_threat_category = vm.filterThreatCategory
                             d.filter_threat_current_impact = vm.filterThreatCurrentImpact
                             d.filter_threat_potential_impact = vm.filterThreatPotentialImpact
+                            d.filter_threat_status = vm.filterThreatStatus
                             d.filter_observed_from_date = vm.filterObservedFromDate
                             d.filter_observed_to_date = vm.filterObservedToDate
                         },
@@ -371,6 +388,7 @@ export default {
                 this.filterThreatCategory === 'all' &&
                 this.filterThreatCurrentImpact === 'all' &&
                 this.filterThreatPotentialImpact === 'all' &&
+                this.filterThreatStatus === 'all' &&
                 this.filterObservedFromDate === '' &&
                 this.filterObservedToDate === ''
                 ){
@@ -400,6 +418,10 @@ export default {
                 vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
             },
             filterThreatPotentialImpact: function(){
+                let vm = this;
+                vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
+            },
+            filterThreatStatus: function(){
                 let vm = this;
                 vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
             },

--- a/boranga/frontend/boranga/src/components/common/occurrence/ocr_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/ocr_threats.vue
@@ -35,6 +35,16 @@
                     </div>
                     <div class="col-md-3">
                         <div class="form-group">
+                            <label for="">Status:</label>
+                            <select class="form-select" v-model="filterThreatStatus">
+                                <option value="all">All</option>
+                                <option v-for="option in threat_status_filter_list" :value="option.id">{{option.name}}
+                                </option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div class="form-group">
                             <label for="">Date Observed From:</label>
                             <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="observed_from_date" v-model="filterObservedFromDate">
                         </div>
@@ -116,12 +126,18 @@ export default {
             filterThreatCategory: 'all',
             filterThreatCurrentImpact: 'all',
             filterThreatPotentialImpact: 'all',
+            filterThreatStatus: 'all',
             filterObservedFromDate: '',
             filterObservedToDate: '',
 
             threat_category_filter_list: [],
             threat_current_impact_filter_list: [],
             threat_potential_impact_filter_list: [],
+
+            threat_status_filter_list: [
+                {id:"active",name:"Active"},
+                {id:"removed",name:"Removed"},
+            ],
 
             threats_headers: ['Number', 'Category', 'Date Observed', 'Threat Agent', 'Comments', 'Threat Source',
                 'Current Impact', 'Potential Impact', 'Action'],
@@ -144,6 +160,7 @@ export default {
                             d.filter_threat_category = vm.filterThreatCategory
                             d.filter_threat_current_impact = vm.filterThreatCurrentImpact
                             d.filter_threat_potential_impact = vm.filterThreatPotentialImpact
+                            d.filter_threat_status = vm.filterThreatStatus
                             d.filter_observed_from_date = vm.filterObservedFromDate
                             d.filter_observed_to_date = vm.filterObservedToDate
                         },
@@ -331,6 +348,7 @@ export default {
                 if(this.filterThreatCategory === 'all' &&
                 this.filterThreatCurrentImpact === 'all' &&
                 this.filterThreatPotentialImpact === 'all' &&
+                this.filterThreatStatus === 'all' &&
                 this.filterObservedFromDate === '' &&
                 this.filterObservedToDate === ''
                 ){
@@ -356,6 +374,10 @@ export default {
             vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
         },
         filterThreatPotentialImpact: function(){
+            let vm = this;
+            vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
+        },
+        filterThreatStatus: function(){
             let vm = this;
             vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
         },

--- a/boranga/frontend/boranga/src/components/common/species_communities/add_threat.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/add_threat.vue
@@ -5,7 +5,7 @@
                 <div class="row">
                     <form class="form-horizontal" name="threatForm">
                         <alert :show.sync="showError" type="danger"><strong>{{ errorString }}</strong></alert>
-                        <alert v-if="change_warning" type="warning"><strong>{{ change_warning }}</strong></alert>
+                        <alert v-if="change_warning && !isReadOnly" type="warning"><strong>{{ change_warning }}</strong></alert>
                         <div class="col-sm-12">
                             <div class="form-group">
                                 <div class="row mb-3">

--- a/boranga/frontend/boranga/src/components/common/species_communities/add_threat.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/add_threat.vue
@@ -5,6 +5,7 @@
                 <div class="row">
                     <form class="form-horizontal" name="threatForm">
                         <alert :show.sync="showError" type="danger"><strong>{{ errorString }}</strong></alert>
+                        <alert v-if="change_warning" type="warning"><strong>{{ change_warning }}</strong></alert>
                         <div class="col-sm-12">
                             <div class="form-group">
                                 <div class="row mb-3">
@@ -142,6 +143,10 @@ export default {
         url: {
             type: String,
             required: true
+        },
+        change_warning: {
+            type: String,
+            required: false
         },
     },
     data: function () {

--- a/boranga/frontend/boranga/src/components/common/species_communities/community_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/community_threats.vue
@@ -78,7 +78,12 @@
             />
         </FormSection>
 
-        <ThreatDetail ref="threat_detail" @refreshFromResponse="refreshFromResponse" :url="threat_url"></ThreatDetail>
+        <ThreatDetail ref="threat_detail" 
+        @refreshFromResponse="refreshFromResponse" 
+        :url="threat_url"
+        :change_warning="changeWarning"
+        >      
+        </ThreatDetail>  
         <div v-if="conservationThreatHistoryId">
             <ConservationThreatHistory
                 ref="conservation_threat_history"
@@ -355,6 +360,15 @@ export default {
             CollapsibleFilters,
         },
         computed: {
+            changeWarning: function() {
+                if (this.species_community.publishing_status.community_public &&
+                    this.species_community.publishing_status.threats_public
+                )
+                    return "Adding or updating a threat will set the Community record to Private."
+                else {
+                    return null
+                }
+            },
             isReadOnly: function(){
                 // this prop (is_readonly = true) is only send from split/combine species form to make the original species readonly
                 if(this.is_readonly){
@@ -475,11 +489,21 @@ export default {
                     this.$refs.conservation_threat_history.isModalOpen = true;
                 });
             },
+            refreshSpeciesCommunity: function() {
+                let vm = this;
+                vm.$parent.refreshSpeciesCommunity();
+            },
             discardThreat:function (id) {
                 let vm = this;
+                let public_message = ""
+                if (vm.species_community.publishing_status.community_public &&
+                    vm.species_community.publishing_status.threats_public
+                ) {
+                    public_message = " Doing so will make the Species Record Private"
+                }
                 swal.fire({
                     title: "Remove Threat",
-                    text: "Are you sure you want to remove this Threat?",
+                    text: "Are you sure you want to remove this Threat?" + public_message,
                     icon: "warning",
                     showCancelButton: true,
                     confirmButtonText: 'Remove Threat',
@@ -495,6 +519,7 @@ export default {
                                 confirmButtonColor:'#226fbb',
                             });
                             vm.$refs.threats_datatable.vmDataTable.ajax.reload();
+                            vm.refreshSpeciesCommunity();
                         }, (error) => {
                             console.log(error);
                         });
@@ -505,9 +530,15 @@ export default {
             },
             reinstateThreat:function (id) {
                 let vm = this;
+                let public_message = ""
+                if (vm.species_community.publishing_status.community_public &&
+                    vm.species_community.publishing_status.threats_public
+                ) {
+                    public_message = " Doing so will make the Species Record Private"
+                }
                 swal.fire({
                     title: "Reinstate Threat",
-                    text: "Are you sure you want to Reinstate this Threat?",
+                    text: "Are you sure you want to Reinstate this Threat?" + public_message,
                     icon: "question",
                     showCancelButton: true,
                     confirmButtonText: 'Reinstate Threat',
@@ -523,6 +554,7 @@ export default {
                                 confirmButtonColor:'#226fbb',
                             });
                             vm.$refs.threats_datatable.vmDataTable.ajax.reload();
+                            vm.refreshSpeciesCommunity();
                         }, (error) => {
                             console.log(error);
                         });
@@ -533,6 +565,7 @@ export default {
             },
             updatedThreats(){
                 this.$refs.threats_datatable.vmDataTable.ajax.reload();
+                this.refreshSpeciesCommunity();
             },
             addEventListeners:function (){
                 let vm=this;

--- a/boranga/frontend/boranga/src/components/common/species_communities/community_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/community_threats.vue
@@ -35,6 +35,16 @@
                     </div>
                     <div class="col-md-3">
                         <div class="form-group">
+                            <label for="">Status:</label>
+                            <select class="form-select" v-model="filterThreatStatus">
+                                <option value="all">All</option>
+                                <option v-for="option in threat_status_filter_list" :value="option.id">{{option.name}}
+                                </option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div class="form-group">
                             <label for="">Date Observed From:</label>
                             <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="observed_from_date" v-model="filterObservedFromDate">
                         </div>
@@ -129,12 +139,18 @@ export default {
                 filterThreatCategory: 'all',
                 filterThreatCurrentImpact: 'all',
                 filterThreatPotentialImpact: 'all',
+                filterThreatStatus: 'all',
                 filterObservedFromDate: '',
                 filterObservedToDate: '',
 
                 threat_category_filter_list: [],
                 threat_current_impact_filter_list: [],
                 threat_potential_impact_filter_list: [],
+
+                threat_status_filter_list: [
+                    {id:"active",name:"Active"},
+                    {id:"removed",name:"Removed"},
+                ],
 
                 threats_headers:['Number','Category', 'Date Observed', 'Threat Agent', 'Comments',
                                 'Current Impact', 'Potential Impact','Threat Source','Action'],
@@ -157,6 +173,7 @@ export default {
                                 d.filter_threat_category = vm.filterThreatCategory
                                 d.filter_threat_current_impact = vm.filterThreatCurrentImpact
                                 d.filter_threat_potential_impact = vm.filterThreatPotentialImpact
+                                d.filter_threat_status = vm.filterThreatStatus
                                 d.filter_observed_from_date = vm.filterObservedFromDate
                                 d.filter_observed_to_date = vm.filterObservedToDate
                             },
@@ -348,6 +365,7 @@ export default {
                 if(this.filterThreatCategory === 'all' &&
                 this.filterThreatCurrentImpact === 'all' &&
                 this.filterThreatPotentialImpact === 'all' &&
+                this.filterThreatStatus === 'all' &&
                 this.filterObservedFromDate === '' &&
                 this.filterObservedToDate === ''
                 ){
@@ -373,6 +391,10 @@ export default {
                 vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
             },
             filterThreatPotentialImpact: function(){
+                let vm = this;
+                vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
+            },
+            filterThreatStatus: function(){
                 let vm = this;
                 vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
             },

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_threats.vue
@@ -78,7 +78,12 @@
             />
         </FormSection>
 
-        <ThreatDetail ref="threat_detail" @refreshFromResponse="refreshFromResponse" :url="threat_url"></ThreatDetail>
+        <ThreatDetail ref="threat_detail" 
+        @refreshFromResponse="refreshFromResponse" 
+        :url="threat_url"
+        :change_warning="changeWarning"
+        >
+        </ThreatDetail>
         <div v-if="conservationThreatHistoryId">
             <ConservationThreatHistory
                 ref="conservation_threat_history"
@@ -357,6 +362,15 @@ export default {
             CollapsibleFilters,
         },
         computed: {
+            changeWarning: function() {
+                if (this.species_community.publishing_status.species_public &&
+                    this.species_community.publishing_status.threats_public
+                )
+                    return "Adding or updating a threat will set the Species record to Private."
+                else {
+                    return null
+                }
+            },
             isReadOnly: function(){
                 // this prop (is_readonly = true) is only send from split/combine species form to make the original species readonly
                 if(this.is_readonly){
@@ -477,11 +491,22 @@ export default {
                     this.$refs.conservation_threat_history.isModalOpen = true;
                 });
             },
+            refreshSpeciesCommunity: function() {
+                let vm = this;
+                vm.$parent.refreshSpeciesCommunity();
+            },
             discardThreat:function (id) {
                 let vm = this;
+                let public_message = ""
+                if (vm.species_community.publishing_status.species_public &&
+                    vm.species_community.publishing_status.threats_public
+                ) {
+                    public_message = " Doing so will make the Species Record Private"
+                }
+
                 swal.fire({
                     title: "Remove Threat",
-                    text: "Are you sure you want to remove this Threat?",
+                    text: "Are you sure you want to remove this Threat?" + public_message,
                     icon: "warning",
                     showCancelButton: true,
                     confirmButtonText: 'Remove Threat',
@@ -497,6 +522,7 @@ export default {
                                 confirmButtonColor:'#226fbb'
                             });
                             vm.$refs.threats_datatable.vmDataTable.ajax.reload();
+                            vm.refreshSpeciesCommunity();
                         }, (error) => {
                             console.log(error);
                         });
@@ -507,9 +533,16 @@ export default {
             },
             reinstateThreat:function (id) {
                 let vm = this;
+                let public_message = ""
+                if (vm.species_community.publishing_status.species_public &&
+                    vm.species_community.publishing_status.threats_public
+                ) {
+                    public_message = " Doing so will make the Species Record Private"
+                }
+                
                 swal.fire({
                     title: "Reinstate Threat",
-                    text: "Are you sure you want to Reinstate this Threat?",
+                    text: "Are you sure you want to Reinstate this Threat?" + public_message,
                     icon: "question",
                     showCancelButton: true,
                     confirmButtonText: 'Reinstate Threat',
@@ -525,6 +558,7 @@ export default {
                                 confirmButtonColor:'#226fbb',
                             });
                             vm.$refs.threats_datatable.vmDataTable.ajax.reload();
+                            vm.refreshSpeciesCommunity();
                         }, (error) => {
                             console.log(error);
                         });
@@ -535,6 +569,7 @@ export default {
             },
             updatedThreats(){
                 this.$refs.threats_datatable.vmDataTable.ajax.reload();
+                this.refreshSpeciesCommunity();
             },
             addEventListeners:function (){
                 let vm=this;

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_threats.vue
@@ -35,6 +35,16 @@
                     </div>
                     <div class="col-md-3">
                         <div class="form-group">
+                            <label for="">Status:</label>
+                            <select class="form-select" v-model="filterThreatStatus">
+                                <option value="all">All</option>
+                                <option v-for="option in threat_status_filter_list" :value="option.id">{{option.name}}
+                                </option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div class="form-group">
                             <label for="">Date Observed From:</label>
                             <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="observed_from_date" v-model="filterObservedFromDate">
                         </div>
@@ -131,12 +141,18 @@ export default {
                 filterThreatCategory: 'all',
                 filterThreatCurrentImpact: 'all',
                 filterThreatPotentialImpact: 'all',
+                filterThreatStatus: 'all',
                 filterObservedFromDate: '',
                 filterObservedToDate: '',
 
                 threat_category_filter_list: [],
                 threat_current_impact_filter_list: [],
                 threat_potential_impact_filter_list: [],
+                
+                threat_status_filter_list: [
+                    {id:"active",name:"Active"},
+                    {id:"removed",name:"Removed"},
+                ],
 
                 threats_headers:['Number','Category', 'Date Observed', 'Threat Agent', 'Comments',
                                 'Current Impact', 'Potential Impact','Threat Source','Action'],
@@ -159,6 +175,7 @@ export default {
                                 d.filter_threat_category = vm.filterThreatCategory
                                 d.filter_threat_current_impact = vm.filterThreatCurrentImpact
                                 d.filter_threat_potential_impact = vm.filterThreatPotentialImpact
+                                d.filter_threat_status = vm.filterThreatStatus
                                 d.filter_observed_from_date = vm.filterObservedFromDate
                                 d.filter_observed_to_date = vm.filterObservedToDate
                             },
@@ -195,7 +212,7 @@ export default {
                                     return "S" + full.species + " - " + full.threat_number;
                                 }
                                 else{
-                                    return '<s> S'+ full.species_number + " - " + full.threat_number + '</s>'
+                                    return '<s> S'+ full.species + " - " + full.threat_number + '</s>'
                                 }
                             },
 
@@ -350,6 +367,7 @@ export default {
                 if(this.filterThreatCategory === 'all' &&
                 this.filterThreatCurrentImpact === 'all' &&
                 this.filterThreatPotentialImpact === 'all' &&
+                this.filterThreatStatus === 'all' &&
                 this.filterObservedFromDate === '' &&
                 this.filterObservedToDate === ''
                 ){
@@ -375,6 +393,10 @@ export default {
                 vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
             },
             filterThreatPotentialImpact: function(){
+                let vm = this;
+                vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
+            },
+            filterThreatStatus: function(){
                 let vm = this;
                 vm.$refs.threats_datatable.vmDataTable.ajax.reload(); // This calls ajax() backend call.
             },

--- a/boranga/frontend/boranga/src/components/form_species_communities.vue
+++ b/boranga/frontend/boranga/src/components/form_species_communities.vue
@@ -170,6 +170,10 @@ export default {
              set profile tab Active
             //$('#pills-tab a[href="#pills-profile"]').tab('show');
         },*/
+        refreshSpeciesCommunity: function() {
+            let vm = this;
+            vm.$parent.refreshSpeciesCommunity();
+        },
         eventListener: function () {
             let vm = this;
         },

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
@@ -672,6 +672,30 @@ export default {
             vm.species_community = helpers.copyObject(response.body);
             vm.species_community_original = copyObject(vm.species_community);
         },
+        refreshSpeciesCommunity: function () {
+            let vm = this;
+            if (vm.species_community.group_type === 'flora' || vm.species_community.group_type === "fauna") {
+                Vue.http.get(`/api/species/${vm.species_community.id}/internal_species.json`)
+                .then(res => {
+                    vm.species_community = res.body.species_obj;
+                    vm.species_community_original = helpers.copyObject(vm.species_community);
+                    vm.uploadedID = vm.species_community.image_doc;
+                },
+                err => {
+                    console.log(err);
+                });
+            } else {
+                Vue.http.get(`/api/community/${vm.species_community.id}/internal_community.json`)
+                .then(res => {
+                    vm.species_community = res.body.community_obj;
+                    vm.species_community_original = helpers.copyObject(vm.species_community);
+                    vm.uploadedID = vm.species_community.image_doc;
+                },
+                err => {
+                    console.log(err);
+                });
+            }
+        },
         splitSpecies: async function () {
             this.$refs.species_split.species_community_original = this.species_community;
             let newSpeciesId1 = null


### PR DESCRIPTION
A new threat filters has been added for removed/active threats.

S&C threats have been adjusted so that if a change is made to them while the S&C record is public with threats set to public, the S&C record will revert back to private (as it does with any other change). 

Warnings have been implemented to inform the user that change to threats will revert the parent record to a private view.