### PR TITLE
CS get_queryset fixes

### DIFF
--- a/boranga/frontend/boranga/src/components/forms/section_toggle.vue
+++ b/boranga/frontend/boranga/src/components/forms/section_toggle.vue
@@ -4,7 +4,7 @@
             <div class='row show_hide_switch' :id="'show_hide_switch_' + section_body_id" aria-expanded="true"
                 :aria-controls="section_body_id" @click="toggle_show_hide">
                 <div class='col-11' :style="'color:' + customColor">
-                    {{ label }} <span class="h6" :class="subtitleClass">{{ subtitle }}</span>
+                    {{ label }} <span v-if="subtitle" class="h6" :class="subtitleClass">{{ subtitle }}</span>
                     <!-- to display the assessor and referral comments textboxes -->
                     <template v-if="displayCommentSection">
                         <template v-if="!isShowComment">

--- a/boranga/frontend/boranga/src/components/forms/section_toggle.vue
+++ b/boranga/frontend/boranga/src/components/forms/section_toggle.vue
@@ -4,7 +4,7 @@
             <div class='row show_hide_switch' :id="'show_hide_switch_' + section_body_id" aria-expanded="true"
                 :aria-controls="section_body_id" @click="toggle_show_hide">
                 <div class='col-11' :style="'color:' + customColor">
-                    {{ label }} <span class="h6 text-muted">{{ subtitle }}</span>
+                    {{ label }} <span class="h6" :class="subtitleClass">{{ subtitle }}</span>
                     <!-- to display the assessor and referral comments textboxes -->
                     <template v-if="displayCommentSection">
                         <template v-if="!isShowComment">
@@ -38,6 +38,10 @@ export default {
         subtitle: {
             type: String,
             default: '',
+        },
+        subtitleClass: {
+            type: String,
+            default: 'text-muted',
         },
         Index: {},
         hideHeader: {},

--- a/boranga/frontend/boranga/src/components/forms/section_toggle.vue
+++ b/boranga/frontend/boranga/src/components/forms/section_toggle.vue
@@ -4,7 +4,7 @@
             <div class='row show_hide_switch' :id="'show_hide_switch_' + section_body_id" aria-expanded="true"
                 :aria-controls="section_body_id" @click="toggle_show_hide">
                 <div class='col-11' :style="'color:' + customColor">
-                    {{ label }} <span class="h6">{{ subtitle }}</span>
+                    {{ label }} <span class="h6 text-muted">{{ subtitle }}</span>
                     <!-- to display the assessor and referral comments textboxes -->
                     <template v-if="displayCommentSection">
                         <template v-if="!isShowComment">

--- a/boranga/permissions.py
+++ b/boranga/permissions.py
@@ -192,6 +192,12 @@ class IsApprover(BasePermission):
 
 class MeetingPermission(BasePermission):
     def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+
+        if request.user.is_superuser:
+            return True
+
         return (
             is_readonly_user(request)
             or is_conservation_status_assessor(request)
@@ -207,6 +213,12 @@ class MeetingPermission(BasePermission):
 
 class ConservationStatusPermission(BasePermission):
     def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+
+        if request.user.is_superuser:
+            return True
+
         if hasattr(view, "action") and view.action == "create":
             return is_contributor(request)
 
@@ -234,6 +246,12 @@ class ConservationStatusPermission(BasePermission):
 
 class ExternalConservationStatusPermission(BasePermission):
     def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+
+        if request.user.is_superuser:
+            return True
+
         return is_external_contributor(request)
 
     def has_object_permission(self, request, view, obj):
@@ -246,6 +264,12 @@ class ExternalConservationStatusPermission(BasePermission):
 
 class ConservationStatusReferralPermission(BasePermission):
     def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+
+        if request.user.is_superuser:
+            return True
+
         return (
             is_readonly_user(request)
             or is_conservation_status_assessor(request)
@@ -273,6 +297,12 @@ class ConservationStatusReferralPermission(BasePermission):
 
 class ConservationStatusAmendmentRequestPermission(BasePermission):
     def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+
+        if request.user.is_superuser:
+            return True
+
         if hasattr(view, "action") and view.action == "create":
             return is_conservation_status_assessor(request)
 
@@ -295,6 +325,12 @@ class ConservationStatusAmendmentRequestPermission(BasePermission):
 
 class ConservationStatusDocumentPermission(BasePermission):
     def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+
+        if request.user.is_superuser:
+            return True
+
         if hasattr(view, "action") and view.action in ["create"]:
             return (
                 is_conservation_status_assessor(request)

--- a/boranga/permissions.py
+++ b/boranga/permissions.py
@@ -198,6 +198,9 @@ class MeetingPermission(BasePermission):
         if request.user.is_superuser:
             return True
 
+        if hasattr(view, "action") and view.action == "create":
+            return is_conservation_status_approver(request)
+
         return (
             is_readonly_user(request)
             or is_conservation_status_assessor(request)


### PR DESCRIPTION
- Make all new permission classes return False if user is unauthenticated
- Make all new permission classes return True if user is superuser
- Tweak CS get_queryset methods to return correct records based on group membership
- Only allow CS approvers to create meeting records
- Add prop to form section so that sub titles are muted by default. Can be overriden as desired.