### PR TITLE
Latest work

### DIFF
--- a/boranga/components/occurrence/serializers.py
+++ b/boranga/components/occurrence/serializers.py
@@ -77,15 +77,11 @@ class OccurrenceSerializer(serializers.ModelSerializer):
     scientific_name = serializers.CharField(
         source="species.taxonomy.scientific_name", allow_null=True
     )
-    community_name = serializers.CharField(
-        source="community.name", allow_null=True
-    )
+    community_name = serializers.CharField(source="community.name", allow_null=True)
     species_taxonomy_id = serializers.IntegerField(
         source="species.taxonomy.id", allow_null=True
     )
-    community_id = serializers.IntegerField(
-        source="community.id", allow_null=True
-    )
+    community_id = serializers.IntegerField(source="community.id", allow_null=True)
     group_type = serializers.CharField(source="group_type.name", allow_null=True)
     group_type_id = serializers.CharField(source="group_type.id", allow_null=True)
     can_user_edit = serializers.SerializerMethodField()
@@ -288,7 +284,7 @@ class ListInternalOccurrenceReportSerializer(serializers.ModelSerializer):
         source="get_processing_status_display"
     )
     reported_date = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
-    reported_date = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    lodgement_date = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
     assessor_edit = serializers.SerializerMethodField(read_only=True)
     internal_user_edit = serializers.SerializerMethodField()
     can_user_approve = serializers.SerializerMethodField()
@@ -317,6 +313,7 @@ class ListInternalOccurrenceReportSerializer(serializers.ModelSerializer):
             "scientific_name",
             "community_name",
             "reported_date",
+            "lodgement_date",
             "submitter",
             "processing_status",
             "processing_status_display",
@@ -344,6 +341,7 @@ class ListInternalOccurrenceReportSerializer(serializers.ModelSerializer):
             "community",
             "community_name",
             "reported_date",
+            "lodgement_date",
             "submitter",
             "processing_status",
             "processing_status_display",
@@ -961,6 +959,7 @@ class BaseOccurrenceReportSerializer(serializers.ModelSerializer):
         format="%Y-%m-%d %H:%M:%S", required=False, allow_null=True
     )
     observation_date = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    reported_date = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
     submitter_information = SubmitterInformationSerializer()
 
     class Meta:
@@ -975,7 +974,6 @@ class BaseOccurrenceReportSerializer(serializers.ModelSerializer):
             "occurrence_report_number",
             "reported_date",
             "lodgement_date",
-            "reported_date",
             "applicant_type",
             "applicant",
             "submitter",
@@ -1221,6 +1219,11 @@ class InternalOccurrenceReportSerializer(OccurrenceReportSerializer):
     is_new_contributor = serializers.SerializerMethodField()
     submitter_information = SubmitterInformationSerializer(read_only=True)
     external_referral_invites = OCRExternalRefereeInviteSerializer(many=True)
+    lodgement_date = serializers.DateTimeField(
+        format="%Y-%m-%d %H:%M:%S", required=False, allow_null=True
+    )
+    observation_date = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    reported_date = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
 
     class Meta:
         model = OccurrenceReport
@@ -1234,7 +1237,6 @@ class InternalOccurrenceReportSerializer(OccurrenceReportSerializer):
             "occurrence_report_number",
             "reported_date",
             "lodgement_date",
-            "reported_date",
             "applicant_type",
             "applicant",
             "submitter",

--- a/boranga/components/occurrence/serializers.py
+++ b/boranga/components/occurrence/serializers.py
@@ -961,6 +961,8 @@ class BaseOccurrenceReportSerializer(serializers.ModelSerializer):
     observation_date = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
     reported_date = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
     submitter_information = SubmitterInformationSerializer()
+    number_of_observers = serializers.IntegerField(read_only=True)
+    has_main_observer = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = OccurrenceReport
@@ -1006,7 +1008,8 @@ class BaseOccurrenceReportSerializer(serializers.ModelSerializer):
             "observation_date",
             "site",
             "submitter_information",
-            "submitter_information",
+            "number_of_observers",
+            "has_main_observer",
         )
 
     def get_readonly(self, obj):
@@ -1283,6 +1286,8 @@ class InternalOccurrenceReportSerializer(OccurrenceReportSerializer):
             "site",
             "submitter_information",
             "external_referral_invites",
+            "number_of_observers",
+            "has_main_observer",
         )
 
     def get_readonly(self, obj):

--- a/boranga/frontend/boranga/src/components/common/occurrence/add_observer_detail.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/add_observer_detail.vue
@@ -3,7 +3,7 @@
         <modal transition="modal fade" @ok="ok()" @cancel="cancel()" :title="title" large>
             <div class="container-fluid">
                 <div class="row">
-                    <form class="form-horizontal needs-validation" name="observerDetailForm" novalidate>
+                    <form v-if="showForm" class="form-horizontal needs-validation" name="observerDetailForm" novalidate>
                         <alert :show.sync="showError" type="danger"><strong>{{ errorString }}</strong></alert>
                         <div class="col-sm-12">
                             <div class="form-group">
@@ -13,7 +13,7 @@
                                     </div>
                                     <div class="col-sm-9">
                                         <input type="text" class="form-control" :disabled="isReadOnly"
-                                            v-model="observerObj.observer_name" ref="observer_name" required />
+                                            v-model="observerObj.observer_name" ref="observer_name" required autofocus />
                                     </div>
                                 </div>
                                 <div class="row mb-3">
@@ -67,7 +67,9 @@
                                     <div v-if="!isReadOnly" class="col-sm-9">
                                         <button type="button" class="btn btn-primary mb-2" @click="clearForm">Clear
                                             Form</button><br />
-                                        <button type="button" class="btn btn-primary" @click="populateWithSubmitterInformation()">Populate Form with Submitter Details</button>
+                                        <button type="button" class="btn btn-primary"
+                                            @click="populateWithSubmitterInformation()">Populate Form with Submitter
+                                            Details</button>
                                     </div>
                                 </div>
                             </div>
@@ -150,13 +152,22 @@ export default {
         },
         isReadOnly: function () {
             return this.observer_detail_action === "view" ? true : false;
+        },
+        showForm: function () {
+            if (['view', 'edit'].includes(this.observer_detail_action)) {
+                return this.observerObj.id ? true : false;
+            } else {
+                return true;
+            }
         }
     },
     watch: {
         isModalOpen: function (val) {
             if (val) {
                 this.$nextTick(() => {
-                    this.$refs.observer_name.focus();
+                    if(this.$refs.observer_name){
+                        this.$refs.observer_name.focus();
+                    }
                     if (this.occurrence_report.has_main_observer) {
                         this.observerObj.main_observer = false;
                     } else {

--- a/boranga/frontend/boranga/src/components/common/occurrence/observer_datatable.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/observer_datatable.vue
@@ -256,11 +256,11 @@ export default {
             this.$refs.observer_detail.observer_detail_action = 'add';
             this.$refs.observer_detail.isModalOpen = true;
         },
-        editObserverDetail: function (id) {
+        editObserverDetail: async function (id) {
             let vm = this;
             this.$refs.observer_detail.observer_detail_id = id;
             this.$refs.observer_detail.observer_detail_action = 'edit';
-            Vue.http.get(helpers.add_endpoint_json(api_endpoints.observer_detail, id)).then((response) => {
+            await Vue.http.get(helpers.add_endpoint_json(api_endpoints.observer_detail, id)).then((response) => {
                 this.$refs.observer_detail.observerObj = response.body;
             },
                 err => {
@@ -268,11 +268,11 @@ export default {
                 });
             this.$refs.observer_detail.isModalOpen = true;
         },
-        viewObserverDetail: function (id) {
+        viewObserverDetail: async function (id) {
             let vm = this;
             this.$refs.observer_detail.observer_detail_id = id;
             this.$refs.observer_detail.observer_detail_action = 'view';
-            Vue.http.get(helpers.add_endpoint_json(api_endpoints.observer_detail, id)).then((response) => {
+            await Vue.http.get(helpers.add_endpoint_json(api_endpoints.observer_detail, id)).then((response) => {
                 this.$refs.observer_detail.observerObj = response.body;
             },
                 err => {

--- a/boranga/frontend/boranga/src/components/common/occurrence/occ_locations.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occ_locations.vue
@@ -80,8 +80,7 @@
 
             <!-- -------------------------------- -->
             <div class="row mb-3">
-                <label for="" class="col-sm-3 control-label fw-bold">Location Description: <span
-                        class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 control-label">Location Description:</label>
                 <div class="col-sm-9">
                     <textarea id="loc_description" v-model="occurrence_obj.location.location_description
                         " :disabled="isReadOnly" class="form-control" rows="2" placeholder="" />
@@ -151,7 +150,8 @@
                 </div>
             </div>-->
             <div class="row mb-3">
-                <label for="" class="col-sm-3 control-label">Location Accuracy:</label>
+                <label for="" class="col-sm-3 control-label fw-bold">Location Accuracy: <span
+                    class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <select v-model="occurrence_obj.location.location_accuracy_id
                         " :disabled="isReadOnly" class="form-select">

--- a/boranga/frontend/boranga/src/components/common/occurrence/occ_observation.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occ_observation.vue
@@ -74,7 +74,8 @@
                 </div>
             </div>
             <div class="row mb-3">
-                <label for="" class="col-sm-3 control-label">Identification Certainty:</label>
+                <label for="" class="col-sm-3 control-label fw-bold">Identification Certainty: <span
+                    class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <select :disabled="isReadOnly" class="form-select"
                         v-model="occurrence_obj.identification.identification_certainty_id">

--- a/boranga/frontend/boranga/src/components/common/occurrence_report_community_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_report_community_dashboard.vue
@@ -295,7 +295,7 @@ export default {
             return this.profile && this.profile.groups.includes(constants.GROUPS.INTERNAL_CONTRIBUTORS);
         },
         datatable_headers: function () {
-            return ['ID', 'Number', 'Occurrence', 'Community Name', 'Observation Date', 'Main Observer', 'Submission Date', 'Submitter', 'Status', 'Action']
+            return ['ID', 'Number', 'Occurrence', 'Community Name', 'Observation Date', 'Main Observer', 'Submitted on', 'Submitter', 'Status', 'Action']
         },
         column_id: function () {
             return {
@@ -373,13 +373,13 @@ export default {
                 name: "main_observer",
             }
         },
-        column_submission_date_time: function () {
+        column_lodgement_date: function () {
             return {
-                data: "reported_date",
+                data: "lodgement_date",
                 orderable: true,
                 searchable: true,
                 visible: true,
-                name: "reported_date",
+                name: "lodgement_date",
             }
         },
         column_submitter: function () {
@@ -459,7 +459,7 @@ export default {
                 vm.column_community_name,
                 vm.column_observation_date_time,
                 vm.column_main_observer,
-                vm.column_submission_date_time,
+                vm.column_lodgement_date,
                 vm.column_submitter,
                 vm.column_status,
                 vm.column_action,

--- a/boranga/frontend/boranga/src/components/common/occurrence_report_community_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_report_community_dashboard.vue
@@ -27,14 +27,14 @@
                         </select>
                     </div>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <div class="form-group">
                         <label for="">Observation Date Range:</label>
                         <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="observation_from_date"
                             v-model="filterOCRCommunityObservationFromDate">
                     </div>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <div class="form-group">
                         <label for=""></label>
                         <input type="date" class="form-control" placeholder="DD/MM/YYYY" id="observation_from_date"

--- a/boranga/frontend/boranga/src/components/common/occurrence_report_fauna_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_report_fauna_dashboard.vue
@@ -296,7 +296,7 @@ export default {
             return this.profile && this.profile.groups.includes(constants.GROUPS.INTERNAL_CONTRIBUTORS);
         },
         datatable_headers: function () {
-            return ['ID', 'Number', 'Occurrence', 'Scientific Name', 'Observation Date', 'Main Observer', 'Submission Date', 'Submitter', 'Status', 'Action']
+            return ['ID', 'Number', 'Occurrence', 'Scientific Name', 'Observation Date', 'Main Observer', 'Submitted on', 'Submitter', 'Status', 'Action']
         },
         column_id: function () {
             return {
@@ -374,13 +374,13 @@ export default {
                 name: "main_observer",
             }
         },
-        column_submission_date_time: function () {
+        column_lodgement_date: function () {
             return {
-                data: "reported_date",
+                data: "lodgement_date",
                 orderable: true,
                 searchable: true,
                 visible: true,
-                name: "reported_date",
+                name: "lodgement_date",
             }
         },
         column_submitter: function () {
@@ -460,7 +460,7 @@ export default {
                 vm.column_scientific_name,
                 vm.column_observation_date_time,
                 vm.column_main_observer,
-                vm.column_submission_date_time,
+                vm.column_lodgement_date,
                 vm.column_submitter,
                 vm.column_status,
                 vm.column_action,

--- a/boranga/frontend/boranga/src/components/common/occurrence_report_flora_dashboard.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence_report_flora_dashboard.vue
@@ -300,7 +300,7 @@ export default {
             return this.profile && this.profile.groups.includes(constants.GROUPS.INTERNAL_CONTRIBUTORS);
         },
         datatable_headers: function () {
-            return ['ID', 'Number', 'Occurrence', 'Scientific Name', 'Observation Date', 'Main Observer', 'Submission Date', 'Submitter', 'Status', 'Action']
+            return ['ID', 'Number', 'Occurrence', 'Scientific Name', 'Observation Date', 'Main Observer', 'Submitted on', 'Submitter', 'Status', 'Action']
         },
         column_id: function () {
             return {
@@ -377,13 +377,13 @@ export default {
                 name: "main_observer",
             }
         },
-        column_submission_date_time: function () {
+        column_lodgement_date: function () {
             return {
-                data: "reported_date",
+                data: "lodgement_date",
                 orderable: true,
                 searchable: true,
                 visible: true,
-                name: "reported_date",
+                name: "lodgement_date",
             }
         },
         column_submitter: function () {
@@ -461,7 +461,7 @@ export default {
                 vm.column_scientific_name,
                 vm.column_observation_date_time,
                 vm.column_main_observer,
-                vm.column_submission_date_time,
+                vm.column_lodgement_date,
                 vm.column_submitter,
                 vm.column_status,
                 vm.column_action,

--- a/boranga/frontend/boranga/src/components/common/submission.vue
+++ b/boranga/frontend/boranga/src/components/common/submission.vue
@@ -11,7 +11,7 @@
                 Contributor</span>
         </div>
         <div v-if="lodgement_date" class="card-body border-top py-2">
-            <strong>Lodged on</strong>
+            <strong>Submitted on</strong>
             {{ lodgement_date | formatDate }}
         </div>
         <div v-if="enableHistory" class="card-body border-top py-2">

--- a/boranga/frontend/boranga/src/components/common/submission.vue
+++ b/boranga/frontend/boranga/src/components/common/submission.vue
@@ -11,8 +11,8 @@
                 Contributor</span>
         </div>
         <div v-if="lodgement_date" class="card-body border-top py-2">
-            <strong>Submitted on</strong>
-            {{ lodgement_date | formatDate }}
+            <strong>Submitted on</strong><br />
+            {{ lodgement_date | formatDateDay }} <span class="fw-light">at</span> {{ lodgement_date | formatDateTime }}
         </div>
         <div v-if="enableHistory" class="card-body border-top py-2">
             <table class="table small-table">
@@ -52,8 +52,11 @@ export default {
         },
     },
     filters: {
-        formatDate: function (data) {
-            return data ? moment(data).format('DD/MM/YYYY HH:mm:ss') : '';
+        formatDateDay: function (data) {
+            return data ? moment(data).format('DD/MM/YYYY') : '';
+        },
+        formatDateTime: function (data) {
+            return data ? moment(data).format('HH:mm:ss A') : '';
         }
     },
 }

--- a/boranga/frontend/boranga/src/components/external/occurrence/occurrence_report_proposal.vue
+++ b/boranga/frontend/boranga/src/components/external/occurrence/occurrence_report_proposal.vue
@@ -218,6 +218,10 @@ export default {
                     title: 'Saved',
                     text: 'Your report has been saved',
                     icon: 'success',
+                    buttonsStyling: false,
+                    customClass: {
+                        confirmButton: 'btn btn-primary',
+                    },
                 });
                 vm.savingOCRProposal = false;
                 const resData = res.data;

--- a/boranga/frontend/boranga/src/components/internal/meetings/meeting.vue
+++ b/boranga/frontend/boranga/src/components/internal/meetings/meeting.vue
@@ -180,9 +180,7 @@ export default {
             }
         },
         canSeeSubmission: function () {
-            //return this.proposal && (this.proposal.processing_status != 'With Assessor (Requirements)' && this.proposal.processing_status != 'With Approver' && !this.isFinalised)
-            //return this.proposal && (this.proposal.processing_status != 'With Assessor (Requirements)')
-            return true
+            return this.meeting_obj && this.meeting_obj.lodgement_date
         },
         userCanEdit: function () {
             return this.meeting_obj.can_user_edit;

--- a/boranga/frontend/boranga/src/components/internal/occurrence/occurrence.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/occurrence.vue
@@ -4,7 +4,7 @@
             <div v-if="occurrence" class="col">
                 <h3>Occurrence: {{ occurrence.occurrence_number }} - <span class="text-capitalize">{{ display_group_type
                         }}</span></h3>
-                    <h4 v-if="occurrence.combined_occurrence" class="text-muted mb-3">
+                <h4 v-if="occurrence.combined_occurrence" class="text-muted mb-3">
                     Combined in to Occurrence:
                     <template>
                         OCC{{ occurrence.combined_occurrence_id }} <small><a
@@ -28,58 +28,53 @@
                                     Workflow
                                 </div>
                                 <div class="card-body card-collapse">
-                                    <div class="row">
-                                        <div class="col-sm-12">
-                                            <strong>Status</strong><br />
-                                            {{ occurrence.processing_status }}
-                                        </div>
-                                        <div class="col-sm-12">
-                                            <div class="separator"></div>
-                                        </div>
-                                        <div class="col-sm-12 top-buffer-s">
-                                            <template v-if="hasUserEditMode">
-                                                <div class="row">
-                                                    <div class="col-sm-12">
-                                                        <strong>Action</strong><br />
-                                                    </div>
+                                    <strong>Status</strong><br />
+                                    {{ occurrence.processing_status }}
+                                </div>
+                                <div class="card-body border-top">
+                                    <div class="col-sm-12">
+                                        <template v-if="hasUserEditMode">
+                                            <div class="row mb-2">
+                                                <div class="col-sm-12">
+                                                    <strong>Action</strong><br />
                                                 </div>
-                                                <div v-if="isDraft" class="row">
-                                                    <div class="col-sm-12">
-                                                        <button style="width:80%;" class="btn btn-primary mb-2"
-                                                            @click.prevent="activateOccurrence()">Activate</button><br />
-                                                    </div>
+                                            </div>
+                                            <div v-if="isDraft" class="row">
+                                                <div class="col-sm-12">
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
+                                                        @click.prevent="activateOccurrence()">Activate</button><br />
                                                 </div>
-                                                <div v-else class="row">
-                                                    <div v-if="canLock" class="col-sm-12">
-                                                        <button style="width:80%;" class="btn btn-primary mb-2"
-                                                            @click.prevent="lockOccurrence()">Lock</button><br />
-                                                    </div>
-                                                    <div class="col-sm-12">
-                                                        <button style="width:80%;" class="btn btn-primary mb-2"
-                                                            @click.prevent="splitOccurrence()">Split</button><br />
-                                                    </div>
-                                                    <div class="col-sm-12">
-                                                        <button style="width:80%;" class="btn btn-primary mb-2"
-                                                            @click.prevent="combineOccurrence()">Combine</button><br />
-                                                    </div>
-                                                    <div v-if="canClose" class="col-sm-12">
-                                                        <button style="width:80%;" class="btn btn-primary mb-2"
-                                                            @click.prevent="closeOccurrence()">Close</button><br />
-                                                    </div>
-                                                </div>
-                                            </template>
-                                            <template v-else-if="canUnlock">
-                                                <div class="row">
-                                                    <div class="col-sm-12">
-                                                        <strong>Action</strong><br />
-                                                    </div>
+                                            </div>
+                                            <div v-else class="row">
+                                                <div v-if="canLock" class="col-sm-12">
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
+                                                        @click.prevent="lockOccurrence()">Lock</button><br />
                                                 </div>
                                                 <div class="col-sm-12">
                                                     <button style="width:80%;" class="btn btn-primary mb-2"
-                                                        @click.prevent="unlockOccurrence()">Unlock</button><br />
+                                                        @click.prevent="splitOccurrence()">Split</button><br />
                                                 </div>
-                                            </template>
-                                        </div>
+                                                <div class="col-sm-12">
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
+                                                        @click.prevent="combineOccurrence()">Combine</button><br />
+                                                </div>
+                                                <div v-if="canClose" class="col-sm-12">
+                                                    <button style="width:80%;" class="btn btn-primary mb-2"
+                                                        @click.prevent="closeOccurrence()">Close</button><br />
+                                                </div>
+                                            </div>
+                                        </template>
+                                        <template v-else-if="canUnlock">
+                                            <div class="row mb-2">
+                                                <div class="col-sm-12">
+                                                    <strong>Action</strong><br />
+                                                </div>
+                                            </div>
+                                            <div class="col-sm-12">
+                                                <button style="width:80%;" class="btn btn-primary mb-2"
+                                                    @click.prevent="unlockOccurrence()">Unlock</button><br />
+                                            </div>
+                                        </template>
                                     </div>
                                 </div>
 
@@ -119,8 +114,8 @@
         </div>
         <!-- <OccurrenceSplit ref="occurrence_split" :occurrence="occurrence" :is_internal="true"
             @refreshFromResponse="refreshFromResponse" />-->
-        <OccurrenceCombine v-if="occurrence" ref="occurrence_combine" :main_occurrence_obj="occurrence" :is_internal="true"
-            @refreshFromResponse="refreshFromResponse" :key="combine_key"/>
+        <OccurrenceCombine v-if="occurrence" ref="occurrence_combine" :main_occurrence_obj="occurrence"
+            :is_internal="true" @refreshFromResponse="refreshFromResponse" :key="combine_key" />
     </div>
 
 </template>
@@ -563,6 +558,20 @@ export default {
         combineOccurrence: async function () {
             this.$refs.occurrence_combine.isModalOpen = true;
         },
+        fetchOccurrence: function () {
+            let vm = this;
+            Vue.http.get(`/api/occurrence/${this.$route.params.occurrence_id}/`).then(res => {
+                vm.occurrence = res.body;
+            },
+                err => {
+                    console.log(err);
+                });
+        },
+    },
+    created: function () {
+        if (!this.occurrence) {
+            this.fetchOccurrence();
+        }
     },
     updated: function () {
         let vm = this;

--- a/boranga/settings.py
+++ b/boranga/settings.py
@@ -364,6 +364,7 @@ CACHE_KEY_PROXY_NODE_DATA = "proxy-node-data-{request_path}"
 CACHE_KEY_MAP_OCCURRENCES = "map-occurrences"
 CACHE_KEY_MAP_OCCURRENCE_REPORTS = "map-occurrence-reports"
 CACHE_KEY_USER_BELONGS_TO_GROUP = "user-{user_id}-belongs-to-{group_name}"
+CACHE_KEY_SUPERUSER_IDS = "superuser-ids"
 
 # ---------- Conservation Change Codes ----------
 

--- a/boranga/settings.py
+++ b/boranga/settings.py
@@ -363,6 +363,7 @@ CACHE_KEY_PROXY_LAYER_DATA = "proxy-layer-data-{app_label}-{model_name}"
 CACHE_KEY_PROXY_NODE_DATA = "proxy-node-data-{request_path}"
 CACHE_KEY_MAP_OCCURRENCES = "map-occurrences"
 CACHE_KEY_MAP_OCCURRENCE_REPORTS = "map-occurrence-reports"
+CACHE_KEY_USER_BELONGS_TO_GROUP = "user-{user_id}-belongs-to-{group_name}"
 
 # ---------- Conservation Change Codes ----------
 

--- a/boranga/templates/webtemplate_dbca/includes/primary_menu.html
+++ b/boranga/templates/webtemplate_dbca/includes/primary_menu.html
@@ -3,27 +3,37 @@
 {% load static %}
 
 {% is_internal as is_internal_login %}
-{% show_internal_primary_menu_items as show_internal_primary_menu_items %}
+{% show_internal_species_communities_menu_item as show_internal_species_communities_menu_item %}
+{% show_internal_conservation_status_menu_item as show_internal_conservation_status_menu_item %}
+{% show_internal_occurences_menu_item as show_internal_occurences_menu_item %}
 {% show_meetings_menu_item as show_meetings_menu_item %}
 {% is_external_contributor as is_external_contributor %}
 
 {% if is_internal_login %}
-  {% if show_internal_primary_menu_items %}
+    {% if show_internal_species_communities_menu_item %}
     <li class="nav-item">
-      <a class="nav-link{% if 'species-communities' in request.path %} active{% endif %}" href="/internal/species-communities">Species &amp; Communities</a>
+        <a class="nav-link{% if 'species-communities' in request.path %} active{% endif %}" href="/internal/species-communities">Species &amp; Communities</a>
     </li>
+    {% else %}
     <li class="nav-item">
-      <a class="nav-link{% if 'conservation-status' in request.path %} active{% endif %}" href="/internal/conservation-status">Conservation Status</a>
-    </li>
-    {% if show_meetings_menu_item %}
-    <li class="nav-item">
-      <a class="nav-link{% if 'meetings' in request.path %} active{% endif %}" href="/internal/meetings">Meetings</a>
+        <a class="nav-link{% if 'species-communities' in request.path %} active{% endif %}" href="/external/species-communities">Species &amp; Communities</a>
     </li>
     {% endif %}
+    {% if show_internal_conservation_status_menu_item %}
     <li class="nav-item">
-      <a class="nav-link{% if 'occurrence' in request.path %} active{% endif %}" href="/internal/occurrence">Occurrences</a>
+        <a class="nav-link{% if 'conservation-status' in request.path %} active{% endif %}" href="/internal/conservation-status">Conservation Status</a>
     </li>
-  {% endif %}
+    {% endif %}
+    {% if show_meetings_menu_item %}
+    <li class="nav-item">
+        <a class="nav-link{% if 'meetings' in request.path %} active{% endif %}" href="/internal/meetings">Meetings</a>
+    </li>
+    {% endif %}
+    {% if show_internal_occurences_menu_item %}
+    <li class="nav-item">
+        <a class="nav-link{% if 'occurrence' in request.path %} active{% endif %}" href="/internal/occurrence">Occurrences</a>
+    </li>
+    {% endif %}
 {% else %}
   <li class="nav-item">
     <a class="nav-link{% if 'species-communities' in request.path %} active{% endif %}" href="/external/species-communities">Species &amp; Communities</a>

--- a/boranga/templatetags/users.py
+++ b/boranga/templatetags/users.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 
 import pytz
@@ -9,6 +10,9 @@ from boranga import helpers as boranga_helpers
 from boranga.components.main.models import SystemMaintenance
 
 register = Library()
+
+
+logger = logging.getLogger(__name__)
 
 
 @register.simple_tag(takes_context=True)
@@ -73,7 +77,7 @@ def is_internal_contributor(context):
 
 
 @register.simple_tag(takes_context=True)
-def show_internal_primary_menu_items(context):
+def show_internal_species_communities_menu_item(context):
     request = context["request"]
     if not request.user.is_authenticated:
         return False
@@ -86,6 +90,42 @@ def show_internal_primary_menu_items(context):
         or boranga_helpers.is_occurrence_assessor(request)
         or boranga_helpers.is_readonly_user(request)
         or boranga_helpers.is_species_communities_approver(request)
+    )
+
+
+@register.simple_tag(takes_context=True)
+def show_internal_occurences_menu_item(context):
+    request = context["request"]
+    if not request.user.is_authenticated:
+        return False
+    return (
+        request.user.is_superuser
+        or boranga_helpers.is_conservation_status_approver(request)
+        or boranga_helpers.is_conservation_status_assessor(request)
+        or boranga_helpers.is_internal_contributor(request)
+        or boranga_helpers.is_occurrence_approver(request)
+        or boranga_helpers.is_occurrence_assessor(request)
+        or boranga_helpers.is_readonly_user(request)
+        or boranga_helpers.is_species_communities_approver(request)
+        or boranga_helpers.is_occurrence_report_referee(request)
+    )
+
+
+@register.simple_tag(takes_context=True)
+def show_internal_conservation_status_menu_item(context):
+    request = context["request"]
+    if not request.user.is_authenticated:
+        return False
+    return (
+        request.user.is_superuser
+        or boranga_helpers.is_conservation_status_approver(request)
+        or boranga_helpers.is_conservation_status_assessor(request)
+        or boranga_helpers.is_internal_contributor(request)
+        or boranga_helpers.is_occurrence_approver(request)
+        or boranga_helpers.is_occurrence_assessor(request)
+        or boranga_helpers.is_readonly_user(request)
+        or boranga_helpers.is_species_communities_approver(request)
+        or boranga_helpers.is_conservation_status_referee(request)
     )
 
 


### PR DESCRIPTION
- Change Lodged on label to Submitted on in submission component
- Change OCR filtering to filter on lodgement_date instead of reported_date (reported date is model creation timestamp)
- Change reported_date column to lodgement_date on all OCR datatables
- Further modification of mandatory field indicators
- Add cache to group membership function as there are a lot more permission checks being done now and was leading to slow performance
- More granual checks for who seens which internal primary menu items
- Add missing number_of_observers and has_main_observer fields back into OCR serializers (accidentally removed during merge at some point)
- Tweak observer modal to wait until it has the record loaded (view/update) before showing the modal