### PR TITLE
Map identify geometries

### DIFF
--- a/boranga/frontend/boranga/src/components/common/component_map.vue
+++ b/boranga/frontend/boranga/src/components/common/component_map.vue
@@ -1136,43 +1136,74 @@
                     </div>
                 </div>
 
-                <div id="featureToast" class="toast" style="z-index: 9999">
-                    <template v-if="selectedModel">
-                        <div class="toast-header">
-                            <img src="" class="rounded me-2" alt="" />
-                            <strong class="me-auto">
-                                {{ selectedModel.Label
-                                }}<span
-                                    v-if="
-                                        selectedModel['Identification Number']
-                                    "
-                                    >:</span
-                                >
-                                {{ selectedModel['Identification Number'] }}
-                            </strong>
-                        </div>
-                        <div class="toast-body">
-                            <table class="table table-sm">
-                                <tbody
-                                    v-for="property in Object.keys(
-                                        selectedModel
-                                    )"
-                                    :key="`${property} - ${selectedModel[property]}`"
-                                >
-                                    <tr
+                <!-- Flexbox container for aligning the toasts -->
+                <div
+                    aria-live="polite"
+                    aria-atomic="true"
+                    class="toast-container d-flex justify-content-center align-items-center w-100"
+                >
+                    <div
+                        id="featureToast"
+                        :class="[
+                            cursorInLeftHalfOfMap
+                                ? 'positionToRight'
+                                : 'positionToLeft',
+                            cursorInBottomHalfOfMap
+                                ? 'positionToTop'
+                                : 'positionToBottom',
+                        ]"
+                        class="toast"
+                        aria-live="assertive"
+                        aria-atomic="true"
+                        style="z-index: 9999"
+                    >
+                        <template v-if="selectedModel">
+                            <div class="toast-header">
+                                <img src="" class="rounded me-2" alt="" />
+                                <strong class="me-auto">
+                                    {{ selectedModel.Label
+                                    }}<span
                                         v-if="
-                                            !['Label', 'label'].includes(
-                                                property
-                                            )
+                                            selectedModel[
+                                                'Identification Number'
+                                            ]
                                         "
+                                        >:</span
                                     >
-                                        <th scope="row">{{ property }}</th>
-                                        <td>{{ selectedModel[property] }}</td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </template>
+                                    {{ selectedModel['Identification Number'] }}
+                                </strong>
+                                <button
+                                    type="button"
+                                    class="btn-close"
+                                    data-bs-dismiss="toast"
+                                    aria-label="Close"
+                                ></button>
+                            </div>
+                            <div class="toast-body">
+                                <table class="table table-sm">
+                                    <tbody
+                                        v-for="property in Object.keys(
+                                            selectedModel
+                                        )"
+                                        :key="`${property} - ${selectedModel[property]}`"
+                                    >
+                                        <tr
+                                            v-if="
+                                                !['Label', 'label'].includes(
+                                                    property
+                                                )
+                                            "
+                                        >
+                                            <th scope="row">{{ property }}</th>
+                                            <td>
+                                                {{ selectedModel[property] }}
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </template>
+                    </div>
                 </div>
 
                 <!-- Overlay popup bubble when clicking a DBCA layer feature -->
@@ -1813,6 +1844,8 @@ export default {
             spatialOperationParameters: [1.0],
             fetchTileLayers: fetchTileLayers,
             fetchProposals: fetchProposals,
+            cursorInLeftHalfOfMap: true,
+            cursorInBottomHalfOfMap: true,
         };
     },
     computed: {
@@ -3329,6 +3362,11 @@ export default {
                 vm.map.getTargetElement().style.cursor = hit
                     ? 'help'
                     : 'default';
+
+                const width = vm.map.getViewport().clientWidth;
+                const height = vm.map.getViewport().clientHeight;
+                vm.cursorInLeftHalfOfMap = evt.pixel[0] < width / 2;
+                vm.cursorInBottomHalfOfMap = evt.pixel[1] > height / 2;
 
                 if (selected) {
                     vm.featureToast.show();
@@ -5227,8 +5265,18 @@ export default {
 
 #featureToast {
     position: absolute;
-    bottom: 10px;
-    left: 10px;
+}
+.positionToLeft {
+    left: 60px;
+}
+.positionToRight {
+    right: 20px;
+}
+.positionToTop {
+    top: 20px;
+}
+.positionToBottom {
+    bottom: 20px;
 }
 
 .badge {

--- a/boranga/frontend/boranga/src/components/common/component_map.vue
+++ b/boranga/frontend/boranga/src/components/common/component_map.vue
@@ -1135,113 +1135,39 @@
                         </div>
                     </div>
                 </div>
-                {{selectedModel}}
+
                 <div id="featureToast" class="toast" style="z-index: 9999">
                     <template v-if="selectedModel">
                         <div class="toast-header">
                             <img src="" class="rounded me-2" alt="" />
                             <strong class="me-auto">
-                                {{ selectedModel.label }}:
-                                {{
-                                    selectedModel.occurrence_report_number ||
-                                    selectedModel.occurrence_number ||
-                                    selectedModel.site_number ||
-                                    selectedModel.buffer_radius
-                                }}
+                                {{ selectedModel.Label
+                                }}<span
+                                    v-if="
+                                        selectedModel['Identification Number']
+                                    "
+                                    >:</span
+                                >
+                                {{ selectedModel['Identification Number'] }}
                             </strong>
                         </div>
                         <div class="toast-body">
                             <table class="table table-sm">
-                                <tbody>
+                                <tbody
+                                    v-for="property in Object.keys(
+                                        selectedModel
+                                    )"
+                                    :key="`${property} - ${selectedModel[property]}`"
+                                >
                                     <tr
                                         v-if="
-                                            selectedModel.status ||
-                                            selectedModel.status_display ||
-                                            selectedModel.processing_status_display ||
-                                            selectedModel.processing_status
+                                            !['Label', 'label'].includes(
+                                                property
+                                            )
                                         "
                                     >
-                                        <th scope="row">Processing Status</th>
-                                        <td>
-                                            {{
-                                                selectedModel.status ||
-                                                selectedModel.status_display ||
-                                                selectedModel.processing_status_display ||
-                                                selectedModel.processing_status
-                                            }}
-                                        </td>
-                                    </tr>
-                                    <tr
-                                        v-if="
-                                            selectedModel.copied_from ||
-                                            selectedModel.lodgement_date_display ||
-                                            selectedModel.lodgement_date ||
-                                            selectedModel.created_at ||
-                                            selectedModel.created_at_display
-                                        "
-                                    >
-                                        <th
-                                            v-if="selectedModel.copied_from"
-                                            scope="row"
-                                        >
-                                            Occurrence (original report)
-                                        </th>
-                                        <th v-else scope="row">
-                                            Lodgement Date
-                                        </th>
-                                        <td v-if="selectedModel.copied_from">
-                                            {{
-                                                selectedModel.copied_from
-                                                    .lodgement_date_display
-                                            }}
-                                        </td>
-                                        <td v-else>
-                                            {{
-                                                selectedModel.lodgement_date_display ||
-                                                selectedModel.lodgement_date ||
-                                                selectedModel.created_at ||
-                                                selectedModel.created_at_display
-                                            }}
-                                        </td>
-                                    </tr>
-                                    <tr v-if="selectedModel.geometry_source">
-                                        <th scope="row">Geometry Source</th>
-                                        <td>
-                                            {{ selectedModel.geometry_source }}
-                                        </td>
-                                    </tr>
-                                    <tr v-if="selectedModel.area_sqm">
-                                        <template
-                                            v-if="
-                                                selectedModel.area_sqm > 10000
-                                            "
-                                        >
-                                            <th scope="row">Area (ha)</th>
-                                            <td>
-                                                {{
-                                                    (
-                                                        selectedModel.area_sqm /
-                                                        10000
-                                                    ).toFixed(1)
-                                                }}
-                                            </td>
-                                        </template>
-                                        <template v-else>
-                                            <th scope="row">Area (m&#178;)</th>
-                                            <td>
-                                                {{
-                                                    Math.round(
-                                                        selectedModel.area_sqm
-                                                    )
-                                                }}
-                                            </td>
-                                        </template>
-                                    </tr>
-                                    <tr v-if="selectedModel.site_name">
-                                        <th scope="row">Name</th>
-                                        <td>
-                                            {{ selectedModel.site_name }}
-                                        </td>
+                                        <th scope="row">{{ property }}</th>
+                                        <td>{{ selectedModel[property] }}</td>
                                     </tr>
                                 </tbody>
                             </table>

--- a/boranga/frontend/boranga/src/components/common/occurrence/occ_locations.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occ_locations.vue
@@ -23,6 +23,7 @@
                         ids: occurrenceReportIds,
                         geometry_name: 'ocr_geometry',
                         collapse: true,
+                        property_display_map: ocrPropertyDisplayMap,
                     }" :additional-layers-definitions="[
                         {
                             name: occurrenceLayerName,
@@ -34,6 +35,7 @@
                             api_url: occApiUrl,
                             ids: [occurrence_obj.id],
                             geometry_name: 'occ_geometry',
+                            property_display_map: occPropertyDisplayMap,
                         },
                         {
                             name: 'buffer_layer',
@@ -44,6 +46,7 @@
                             can_buffer: false,
                             handler: bufferGeometryHandler, // Buffer geometries are a property of occurrence geometry. This handler returns the buffer geometries from the occurrence geometries.
                             geometry_name: 'geometry',
+                            property_display_map: bufferPropertyDisplayMap,
                         },
                         {
                             name: 'site_layer',
@@ -322,6 +325,47 @@ export default {
         siteApiUrl: function () {
             // TODO: Update to use the correct endpoint
             return '/api/occurrence_sites/list_for_map/';
+        },
+        ocrPropertyDisplayMap: function () {
+            return {
+                id: 'ID',
+                // name: 'Name',
+                label: 'Label', // Occurrence Report
+                geometry_source: 'Geometry Source',
+                occurrence_report_number: 'Identification Number',
+                processing_status: 'Processing Status',
+                lodgement_date_display: 'Lodgement Date',
+                locked: 'Locked',
+            };
+        },
+        occPropertyDisplayMap: function () {
+            return {
+                id: 'ID',
+                // name: 'Name',
+                label: 'Label', // Occurrence
+                occurrence_number: 'Identification Number', // OCC1
+                geometry_source: 'Geometry Source',
+                processing_status_display: 'Processing Status',
+            };
+        },
+        bufferPropertyDisplayMap: function () {
+            return {
+                id: 'ID',
+                // name: 'Name',
+                label: 'Label', // OCC1 [Buffer]
+                geometry_source: 'Geometry Source',
+                // processing_status: 'Processing Status',
+                // lodgement_date_display: 'Lodgement Date',
+                buffer_radius: 'Buffer Radius [m]',
+            };
+        },
+        sitePropertyDisplayMap: function () {
+            return {
+                id: 'ID', // 8
+                label: 'Label', // Site
+                site_number: 'Identification Number', // ST1
+                site_name: 'Site Name', // My Site
+            };
         },
         bufferGeometriesApiUrl: function () {
             return api_endpoints.occurrence + 'buffer_geometries/';

--- a/boranga/frontend/boranga/src/components/common/occurrence/ocr_location.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/ocr_location.vue
@@ -24,6 +24,7 @@
                         ids: [occurrence_report_obj.id],
                         geometry_name: 'ocr_geometry',
                         collapse: false,
+                        property_display_map: ocrPropertyDisplayMap,
                     }" @validate-feature="validateFeature.bind(this)()" @refreshFromResponse="refreshFromResponse"
                     @crs-select-search="searchForCRS"></MapComponent>
             </div>
@@ -380,6 +381,14 @@ export default {
         },
         proposalApiUrl: function () {
             return api_endpoints.occurrence_report + '/list_for_map/';
+        },
+        ocrPropertyDisplayMap: function () {
+            return {
+                label: 'Label', // Occurrence Report
+                geometry_source: 'Geometry Source',
+                occurrence_report_number: 'Identification Number',
+                processing_status: 'Processing Status',
+            };
         },
     },
     watch: {},


### PR DESCRIPTION
Slight update to how geometry mouseover fearture toasts are created
- Added a mapping-dictionary to the layer definitions to control which properties are to be displayed under which name
- Added a function to compile those properties with re-usablity in mind for future geometry-export tasks
- Changed the toast to preferrably appear in the opposite corner of the map relative to the mouse cursor, to not obstruct the cursor
- Added a close button to the toast window