### PR TITLE
Latest work

### DIFF
--- a/boranga/components/conservation_status/api.py
+++ b/boranga/components/conservation_status/api.py
@@ -630,7 +630,9 @@ class SpeciesConservationStatusPaginatedViewSet(viewsets.ReadOnlyModelViewSet):
     )
     def species_cs_referrals_internal(self, request, *args, **kwargs):
         self.serializer_class = DTConservationStatusReferralSerializer
-        qs = ConservationStatusReferral.objects.filter(referral=request.user.id)
+        qs = ConservationStatusReferral.objects.exclude(
+            processing_status=ConservationStatusReferral.PROCESSING_STATUS_RECALLED
+        ).filter(referral=request.user.id)
         qs = self.filter_queryset(qs)
 
         self.paginator.page_size = qs.count()
@@ -1177,11 +1179,9 @@ class CommunityConservationStatusPaginatedViewSet(viewsets.ReadOnlyModelViewSet)
         permission_classes=[ConservationStatusReferralPermission],
     )
     def community_cs_referrals_internal(self, request, *args, **kwargs):
-        qs = (
-            ConservationStatusReferral.objects.filter(referral=request.user.id)
-            if is_internal(self.request)
-            else ConservationStatusReferral.objects.none()
-        )
+        qs = ConservationStatusReferral.objects.exclude(
+            processing_status=ConservationStatusReferral.PROCESSING_STATUS_RECALLED
+        ).filter(referral=request.user.id)
 
         qs = self.filter_queryset(qs)
 

--- a/boranga/components/conservation_status/api.py
+++ b/boranga/components/conservation_status/api.py
@@ -80,7 +80,6 @@ from boranga.helpers import (
     is_conservation_status_assessor,
     is_conservation_status_referee,
     is_contributor,
-    is_external_contributor,
     is_internal,
     is_internal_contributor,
     is_occurrence_approver,
@@ -2469,7 +2468,7 @@ class ConservationStatusDocumentViewSet(
             serializer = InternalSaveConservationStatusDocumentSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         instance = serializer.save(no_revision=True)
-        if is_external_contributor(self.request):
+        if is_contributor(self.request):
             instance.can_submitter_access = True
             instance.save()
 

--- a/boranga/components/occurrence/api.py
+++ b/boranga/components/occurrence/api.py
@@ -2261,7 +2261,7 @@ class OccurrenceReportViewSet(
             "PATCH",
         ],
         detail=True,
-        permission_classes=[OccurrencePermission]
+        permission_classes=[OccurrencePermission],
     )
     @renderer_classes((JSONRenderer,))
     def update_show_on_map(self, request, *args, **kwargs):
@@ -2616,7 +2616,7 @@ class OccurrenceReportDocumentViewSet(
         instance.add_documents(request, no_revision=True)
         instance.uploaded_by = request.user.id
 
-        if is_external_contributor(self.request):
+        if is_contributor(self.request):
             instance.can_submitter_access = True
 
         instance.save(version_user=request.user)

--- a/boranga/components/users/serializers.py
+++ b/boranga/components/users/serializers.py
@@ -19,6 +19,7 @@ from boranga.components.users.models import (
 )
 from boranga.helpers import (
     is_contributor,
+    is_internal,
     is_occurrence_approver,
     is_occurrence_assessor,
 )
@@ -67,6 +68,8 @@ class UserSerializer(serializers.ModelSerializer):
     cs_referral_count = serializers.SerializerMethodField()
     ocr_referral_count = serializers.SerializerMethodField()
 
+    is_internal = serializers.SerializerMethodField()
+
     class Meta:
         model = EmailUser
         fields = (
@@ -81,9 +84,9 @@ class UserSerializer(serializers.ModelSerializer):
             "address_details",
             "contact_details",
             "full_name",
-            "is_staff",
             "system_settings",
             "groups",
+            "is_internal",
             "cs_referral_count",
             "ocr_referral_count",
         )
@@ -125,6 +128,10 @@ class UserSerializer(serializers.ModelSerializer):
         return groups.filter(
             systemgrouppermission__emailuser=request.user.id
         ).values_list("name", flat=True)
+
+    def get_is_internal(self, obj):
+        request = self.context["request"]
+        return is_internal(request)
 
     def get_cs_referral_count(self, obj):
         return ConservationStatusReferral.objects.filter(referral=obj.id).count()

--- a/boranga/frontend/boranga/src/components/common/conservation_status/cs_documents.vue
+++ b/boranga/frontend/boranga/src/components/common/conservation_status/cs_documents.vue
@@ -227,8 +227,11 @@ export default {
     },
     computed: {
         show_document_actions: function () {
-            return this.conservation_status_obj.can_user_edit || (
-                this.conservation_status_obj.assessor_mode && this.conservation_status_obj.assessor_mode.assessor_can_assess && this.conservation_status_obj.assessor_mode.assessor_level == 'assessor'
+            return (!this.is_internal && this.conservation_status_obj.can_user_edit) || (
+                this.is_internal &&
+                this.conservation_status_obj.assessor_mode &&
+                this.conservation_status_obj.assessor_mode.assessor_can_assess &&
+                this.conservation_status_obj.assessor_mode.assessor_level == 'assessor'
             );
         }
     },

--- a/boranga/frontend/boranga/src/components/common/occurrence/animal_observation.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/animal_observation.vue
@@ -356,11 +356,9 @@ export default {
     },
     methods: {
         calculateTotalNumberSeen: function () {
-            console.log('Calculating total number seen')
             let vm = this;
             vm.total_seen = 0;
             $('input.animal-count-input').each(function (i, n) {
-                console.log('Adding ' + $(n).val())
                 vm.total_seen += parseInt($(n).val(), 10);
             });
             return vm.total_seen;

--- a/boranga/frontend/boranga/src/components/common/occurrence/occ_observation.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occ_observation.vue
@@ -75,7 +75,7 @@
             </div>
             <div class="row mb-3">
                 <label for="" class="col-sm-3 control-label fw-bold">Identification Certainty: <span
-                    class="text-danger">*</span></label>
+                        class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <select :disabled="isReadOnly" class="form-select"
                         v-model="occurrence_obj.identification.identification_certainty_id">
@@ -310,6 +310,34 @@ export default {
                 id: null,
                 name: null,
             });
+        vm.identification_certainty_list = vm.listOfValuesDict.identification_certainty_list;
+        vm.identification_certainty_list.splice(0, 0,
+            {
+                id: null,
+                name: null,
+            });
+        vm.sample_type_list = vm.listOfValuesDict.sample_type_list;
+        vm.sample_type_list.splice(0, 0,
+            {
+                id: null,
+                name: null,
+            });
+        vm.sample_dest_list = vm.listOfValuesDict.sample_dest_list;
+        vm.sample_dest_list.splice(0, 0,
+            {
+                id: null,
+                name: null,
+            });
+        vm.permit_type_list = vm.listOfValuesDict.permit_type_list;
+        vm.permit_type_list.splice(0, 0,
+            {
+                id: null,
+                name: null,
+            });
+    },
+    mounted: function () {
+        let vm = this;
+        vm.eventListeners();
         if (this.isFlora) {
             // using child refs to assign the list values to avoid calling the above api again in plantCount component
             vm.$refs.plantCountDetail.plant_count_method_list = vm.listOfValuesDict.plant_count_method_list;
@@ -370,34 +398,7 @@ export default {
                     name: null,
                 });
         }
-        vm.identification_certainty_list = vm.listOfValuesDict.identification_certainty_list;
-        vm.identification_certainty_list.splice(0, 0,
-            {
-                id: null,
-                name: null,
-            });
-        vm.sample_type_list = vm.listOfValuesDict.sample_type_list;
-        vm.sample_type_list.splice(0, 0,
-            {
-                id: null,
-                name: null,
-            });
-        vm.sample_dest_list = vm.listOfValuesDict.sample_dest_list;
-        vm.sample_dest_list.splice(0, 0,
-            {
-                id: null,
-                name: null,
-            });
-        vm.permit_type_list = vm.listOfValuesDict.permit_type_list;
-        vm.permit_type_list.splice(0, 0,
-            {
-                id: null,
-                name: null,
-            });
-    },
-    mounted: function () {
-        let vm = this;
-        vm.eventListeners();
+
     },
 }
 </script>

--- a/boranga/frontend/boranga/src/components/common/occurrence/occ_observation.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occ_observation.vue
@@ -50,7 +50,7 @@
         <FormSection :formCollapse="false" label="Plant Count" :Index="plantCountBody" v-if="isFlora">
             <PlantCount v-if="isFlora" :plant_count="occurrence_obj.plant_count" :is_report=false
                 :occurrence_id="occurrence_obj.id" id="plantCountDetail" :is_external="is_external"
-                :isReadOnly="isReadOnly" ref="plantCountDetail">
+                :isReadOnly="isReadOnly" ref="plantCountDetail" @mounted="populatePlantCountLookups">
             </PlantCount>
             <RelatedReports :isReadOnly="isReadOnly" :occurrence_obj=occurrence_obj :section_type="'plant_count'"
                 @copyUpdate="copyUpdate" />
@@ -59,7 +59,7 @@
         <FormSection :formCollapse="false" label="Animal Observation" :Index="animalObsBody" v-if="isFauna">
             <AnimalObservation v-if="isFauna" :animal_observation="occurrence_obj.animal_observation" :is_report=false
                 :occurrence_id="occurrence_obj.id" id="animalObservationDetail" :is_external="is_external"
-                :isReadOnly="isReadOnly" ref="animalObservationDetail">
+                :isReadOnly="isReadOnly" ref="animalObservationDetail" @mounted="populateAnimalObservationLookups">
             </AnimalObservation>
             <RelatedReports :isReadOnly="isReadOnly" :occurrence_obj=occurrence_obj :section_type="'animal_observation'"
                 @copyUpdate="copyUpdate" />
@@ -298,6 +298,67 @@ export default {
                 vm.updatingIdentificationDetails = false;
             });
         },
+        populatePlantCountLookups: function () {
+            // using child refs to assign the list values to avoid calling the above api again in plantCount component
+            vm.$refs.plantCountDetail.plant_count_method_list = vm.listOfValuesDict.plant_count_method_list;
+            vm.$refs.plantCountDetail.plant_count_method_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+            vm.$refs.plantCountDetail.plant_count_accuracy_list = vm.listOfValuesDict.plant_count_accuracy_list;
+            vm.$refs.plantCountDetail.plant_count_accuracy_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+            vm.$refs.plantCountDetail.plant_condition_list = vm.listOfValuesDict.plant_condition_list;
+            vm.$refs.plantCountDetail.plant_condition_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+            vm.$refs.plantCountDetail.counted_subject_list = vm.listOfValuesDict.counted_subject_list;
+            vm.$refs.plantCountDetail.counted_subject_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+        },
+        populateAnimalObservationLookups: function () {
+            // using child refs to assign the list values to avoid calling the above api again in AnimalObservation component
+            vm.$refs.animalObservationDetail.primary_detection_method_list = vm.listOfValuesDict.primary_detection_method_list;
+            vm.$refs.animalObservationDetail.primary_detection_method_list.splice(0, 0,
+                {
+                    id: '',
+                    name: '',
+                });
+            vm.$refs.animalObservationDetail.secondary_sign_list = vm.listOfValuesDict.secondary_sign_list;
+            vm.$refs.animalObservationDetail.secondary_sign_list.splice(0, 0,
+                {
+                    id: '',
+                    name: '',
+                });
+            vm.$refs.animalObservationDetail.reprod_state_list = vm.listOfValuesDict.reprod_state_list;
+            vm.$refs.animalObservationDetail.reprod_state_list.splice(0, 0,
+                {
+                    id: '',
+                    name: '',
+                });
+            vm.$refs.animalObservationDetail.death_reason_list = vm.listOfValuesDict.death_reason_list;
+            vm.$refs.animalObservationDetail.death_reason_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+            vm.$refs.animalObservationDetail.animal_health_list = vm.listOfValuesDict.animal_health_list;
+            vm.$refs.animalObservationDetail.animal_health_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+        }
+
     },
     created: async function () {
         let vm = this;
@@ -338,67 +399,6 @@ export default {
     mounted: function () {
         let vm = this;
         vm.eventListeners();
-        if (this.isFlora) {
-            // using child refs to assign the list values to avoid calling the above api again in plantCount component
-            vm.$refs.plantCountDetail.plant_count_method_list = vm.listOfValuesDict.plant_count_method_list;
-            vm.$refs.plantCountDetail.plant_count_method_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-            vm.$refs.plantCountDetail.plant_count_accuracy_list = vm.listOfValuesDict.plant_count_accuracy_list;
-            vm.$refs.plantCountDetail.plant_count_accuracy_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-            vm.$refs.plantCountDetail.plant_condition_list = vm.listOfValuesDict.plant_condition_list;
-            vm.$refs.plantCountDetail.plant_condition_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-            vm.$refs.plantCountDetail.counted_subject_list = vm.listOfValuesDict.counted_subject_list;
-            vm.$refs.plantCountDetail.counted_subject_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-        }
-        else if (this.isFauna) {
-            // using child refs to assign the list values to avoid calling the above api again in AnimalObservation component
-            vm.$refs.animalObservationDetail.primary_detection_method_list = vm.listOfValuesDict.primary_detection_method_list;
-            vm.$refs.animalObservationDetail.primary_detection_method_list.splice(0, 0,
-                {
-                    id: '',
-                    name: '',
-                });
-            vm.$refs.animalObservationDetail.secondary_sign_list = vm.listOfValuesDict.secondary_sign_list;
-            vm.$refs.animalObservationDetail.secondary_sign_list.splice(0, 0,
-                {
-                    id: '',
-                    name: '',
-                });
-            vm.$refs.animalObservationDetail.reprod_state_list = vm.listOfValuesDict.reprod_state_list;
-            vm.$refs.animalObservationDetail.reprod_state_list.splice(0, 0,
-                {
-                    id: '',
-                    name: '',
-                });
-            vm.$refs.animalObservationDetail.death_reason_list = vm.listOfValuesDict.death_reason_list;
-            vm.$refs.animalObservationDetail.death_reason_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-            vm.$refs.animalObservationDetail.animal_health_list = vm.listOfValuesDict.animal_health_list;
-            vm.$refs.animalObservationDetail.animal_health_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-        }
-
     },
 }
 </script>

--- a/boranga/frontend/boranga/src/components/common/occurrence/occurrence_report_profile.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occurrence_report_profile.vue
@@ -1,7 +1,7 @@
 <template lang="html">
     <div id="speciesOccurrenceReport">
         <FormSection :formCollapse="false" label="Occurrence Report" Index="occurrence_report">
-            <fieldset id="occurrence-report-profile-fieldset" @change="$emit('saveOccurrenceReport');">
+            <fieldset id="occurrence-report-profile-fieldset" @change="saveOccurrenceReport">
                 <template v-if="!is_external">
                     <CollapsibleComponent component_title="Assessment Comments" ref="assessment_comments"
                         :collapsed="false">
@@ -244,6 +244,7 @@ export default {
                     vm.occurrence_report_obj.species_id = null;
                     vm.species_display = '';
                     vm.taxon_previous_name = '';
+                    vm.$emit('saveOccurrenceReport');
                 })
                 // eslint-disable-next-line no-unused-vars
                 .on('select2:open', function (e) {
@@ -297,12 +298,14 @@ export default {
                     let data = e.params.data.id;
                     vm.occurrence_report_obj.community_id = data;
                     vm.community_display = e.params.data.text;
+                    vm.$emit('saveOccurrenceReport');
                 })
                 .on('select2:unselect', function (e) {
                     // eslint-disable-next-line no-unused-vars
                     var selected = $(e.currentTarget);
                     vm.occurrence_report_obj.community_id = null;
                     vm.community_display = '';
+                    vm.$emit('saveOccurrenceReport');
                 })
                 // eslint-disable-next-line no-unused-vars
                 .on('select2:open', function (e) {
@@ -385,6 +388,12 @@ export default {
         refreshOccurrenceReport: function () {
             this.$emit('refreshOccurrenceReport');
         },
+        saveOccurrenceReport: function (e) {
+            console.log(e.target.id)
+            if(e.target.id!='select_scientific_name' && e.target.id!='select_community_name'){
+                this.$emit('saveOccurrenceReport');
+            }
+        }
     },
     created: async function () {
         let vm = this;

--- a/boranga/frontend/boranga/src/components/common/occurrence/occurrence_report_profile.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occurrence_report_profile.vue
@@ -1,120 +1,125 @@
 <template lang="html">
     <div id="speciesOccurrenceReport">
         <FormSection :formCollapse="false" label="Occurrence Report" Index="occurrence_report">
-            <template v-if="!is_external">
-                <CollapsibleComponent component_title="Assessment Comments" ref="assessment_comments"
-                    :collapsed="false">
-                    <div class="row">
-                        <div class="col rounded">
-                            <div class="row">
-                                <div class="col">
-                                    <div class="form-floating m-3">
-                                        <textarea :disabled="deficiency_readonly" class="form-control"
-                                            id="assessor_deficiencies" placeholder="Deficiency Comments"
-                                            v-model="occurrence_report_obj.deficiency_data" />
-                                        <label for="assessor_deficiencies" class="form-label">Deficiency
-                                            Comments</label>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col">
-                                    <div class="form-floating m-3 mt-1">
-                                        <textarea :disabled="assessor_comment_readonly" class="form-control" rows="3"
-                                            id="assessor_comment" placeholder="Assessor Comments"
-                                            v-model="occurrence_report_obj.assessor_data" />
-                                        <label for="" class="col-sm-4 col-form-label">Assessor Comments</label>
-                                    </div>
-                                </div>
-                            </div>
-                            <div v-if="referral_comments_boxes.length > 0">
-                                <div>
-                                    <div class="row mt-2">
-                                        <div class="col ms-3">
-                                            <h6 class="text-muted">Referral Comments</h6>
+            <fieldset id="occurrence-report-profile-fieldset" @change="$emit('saveOccurrenceReport');">
+                <template v-if="!is_external">
+                    <CollapsibleComponent component_title="Assessment Comments" ref="assessment_comments"
+                        :collapsed="false">
+                        <div class="row">
+                            <div class="col rounded">
+                                <div class="row">
+                                    <div class="col">
+                                        <div class="form-floating m-3">
+                                            <textarea :disabled="deficiency_readonly" class="form-control"
+                                                id="assessor_deficiencies" placeholder="Deficiency Comments"
+                                                v-model="occurrence_report_obj.deficiency_data" />
+                                            <label for="assessor_deficiencies" class="form-label">Deficiency
+                                                Comments</label>
                                         </div>
                                     </div>
-                                    <template v-for="ref in referral_comments_boxes">
-                                        <div class="row mb-3">
-                                            <div class="col">
-                                                <div class="form-floating m-3 mt-1">
-                                                    <textarea v-if='!ref.readonly' :disabled="true" :id="ref.name"
-                                                        :name="ref.name" class="form-control" :placeholder="ref.label"
-                                                        v-model="referral.referral_comment" />
-                                                    <textarea v-else :disabled="true" :name="ref.name"
-                                                        :value="ref.value || ''" class="form-control"
-                                                        :placeholder="ref.label" />
-                                                    <label :for="ref.name" class="form-label">{{ ref.label
-                                                        }}</label>
-                                                </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col">
+                                        <div class="form-floating m-3 mt-1">
+                                            <textarea :disabled="assessor_comment_readonly" class="form-control"
+                                                rows="3" id="assessor_comment" placeholder="Assessor Comments"
+                                                v-model="occurrence_report_obj.assessor_data" />
+                                            <label for="" class="col-sm-4 col-form-label">Assessor Comments</label>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div v-if="referral_comments_boxes.length > 0">
+                                    <div>
+                                        <div class="row mt-2">
+                                            <div class="col ms-3">
+                                                <h6 class="text-muted">Referral Comments</h6>
                                             </div>
                                         </div>
-                                    </template>
+                                        <template v-for="ref in referral_comments_boxes">
+                                            <div class="row mb-3">
+                                                <div class="col">
+                                                    <div class="form-floating m-3 mt-1">
+                                                        <textarea v-if='!ref.readonly' :disabled="true" :id="ref.name"
+                                                            :name="ref.name" class="form-control"
+                                                            :placeholder="ref.label"
+                                                            v-model="referral.referral_comment" />
+                                                        <textarea v-else :disabled="true" :name="ref.name"
+                                                            :value="ref.value || ''" class="form-control"
+                                                            :placeholder="ref.label" />
+                                                        <label :for="ref.name" class="form-label">{{ ref.label
+                                                            }}</label>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                    </CollapsibleComponent>
+                </template>
+                <div v-show="!isCommunity">
+                    <div class="row mb-3">
+                        <label for="" class="col-sm-3 control-label fw-bold">Scientific Name: <span
+                                class="text-danger">*</span></label>
+                        <div :id="select_scientific_name" class="col-sm-9">
+                            <select :id="scientific_name_lookup" :ref="scientific_name_lookup" :disabled="isReadOnly"
+                                :name="scientific_name_lookup" class="form-control" />
+                        </div>
                     </div>
-                </CollapsibleComponent>
-            </template>
-            <div v-show="!isCommunity">
-                <div class="row mb-3">
-                    <label for="" class="col-sm-3 control-label fw-bold">Scientific Name: <span class="text-danger">*</span></label>
-                    <div :id="select_scientific_name" class="col-sm-9">
-                        <select :id="scientific_name_lookup" :ref="scientific_name_lookup" :disabled="isReadOnly"
-                            :name="scientific_name_lookup" class="form-control" />
+                    <div class="row mb-3">
+                        <label for="" class="col-sm-3 control-label"></label>
+                        <div class="col-sm-9">
+                            <textarea id="species_display" v-model="species_display" disabled class="form-control"
+                                rows="2" />
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <label for="" class="col-sm-3 control-label">Previous Name:</label>
+                        <div class="col-sm-9">
+                            <input id="previous_name" v-model="taxon_previous_name" readonly type="text"
+                                class="form-control" placeholder="" />
+                        </div>
+                    </div>
+                </div>
+                <div v-show="isCommunity">
+                    <div class="row mb-3">
+                        <label for="" class="col-sm-3 control-label">Community Name:</label>
+                        <div :id="select_community_name" class="col-sm-9">
+                            <select :id="community_name_lookup" :ref="community_name_lookup" :disabled="isReadOnly"
+                                :name="community_name_lookup" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <label for="" class="col-sm-3 control-label"></label>
+                        <div class="col-sm-9">
+                            <textarea id="community_display" v-model="community_display" disabled class="form-control"
+                                rows="2" />
+                        </div>
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label for="" class="col-sm-3 control-label"></label>
+                    <label for="" class="col-sm-3 control-label">Site:</label>
                     <div class="col-sm-9">
-                        <textarea id="species_display" v-model="species_display" disabled class="form-control"
-                            rows="2" />
+                        <textarea id="site" v-model="occurrence_report_obj.site
+                            " :disabled="isReadOnly" class="form-control" rows="1" placeholder="" />
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label for="" class="col-sm-3 control-label">Previous Name:</label>
+                    <label for="" class="col-sm-3 control-label fw-bold">Observation Date: <span
+                            class="text-danger">*</span></label>
                     <div class="col-sm-9">
-                        <input id="previous_name" v-model="taxon_previous_name" readonly type="text"
-                            class="form-control" placeholder="" />
+                        <input v-model="occurrence_report_obj.observation_date
+                            " :disabled="isReadOnly" type="datetime-local" class="form-control" name="start_date"
+                            @change="formatObservationDate()" />
                     </div>
                 </div>
-            </div>
-            <div v-show="isCommunity">
-                <div class="row mb-3">
-                    <label for="" class="col-sm-3 control-label">Community Name:</label>
-                    <div :id="select_community_name" class="col-sm-9">
-                        <select :id="community_name_lookup" :ref="community_name_lookup" :disabled="isReadOnly"
-                            :name="community_name_lookup" class="form-control" />
-                    </div>
-                </div>
-                <div class="row mb-3">
-                    <label for="" class="col-sm-3 control-label"></label>
-                    <div class="col-sm-9">
-                        <textarea id="community_display" v-model="community_display" disabled class="form-control"
-                            rows="2" />
-                    </div>
-                </div>
-            </div>
-            <div class="row mb-3">
-                <label for="" class="col-sm-3 control-label">Site:</label>
-                <div class="col-sm-9">
-                    <textarea id="site" v-model="occurrence_report_obj.site
-                        " :disabled="isReadOnly" class="form-control" rows="1" placeholder="" />
-                </div>
-            </div>
-            <div class="row mb-3">
-                <label for="" class="col-sm-3 control-label fw-bold">Observation Date: <span class="text-danger">*</span></label>
-                <div class="col-sm-9">
-                    <input v-model="occurrence_report_obj.observation_date
-                        " :disabled="isReadOnly" type="datetime-local" class="form-control" name="start_date"
-                        @change="formatObservationDate()" />
-                </div>
-            </div>
-            <ObserverDatatable ref="observer_datatable" :occurrence_report_obj="occurrence_report_obj"
-                :is_external="is_external" :is-read-only="isReadOnly"
-                :show_observer_contact_information="show_observer_contact_information"
-                @refreshOccurrenceReport="refreshOccurrenceReport()">
-            </ObserverDatatable>
+                <ObserverDatatable ref="observer_datatable" :occurrence_report_obj="occurrence_report_obj"
+                    :is_external="is_external" :is-read-only="isReadOnly"
+                    :show_observer_contact_information="show_observer_contact_information"
+                    @refreshOccurrenceReport="refreshOccurrenceReport()">
+                </ObserverDatatable>
+            </fieldset>
         </FormSection>
     </div>
 </template>
@@ -151,7 +156,7 @@ export default {
             default: true,
         },
     },
-    emits: ['refreshOccurrenceReport'],
+    emits: ['refreshOccurrenceReport', 'saveOccurrenceReport'],
     data: function () {
         let vm = this;
         return {
@@ -181,20 +186,23 @@ export default {
     },
     watch: {
         "occurrence_report_obj.observation_date": function () {
-            let vm=this;
-            if(vm.isFauna){
-                if(vm.occurrence_report_obj && vm.occurrence_report_obj.plant_count){
-                    vm.occurrence_report_obj.animal_observation.count_date=vm.occurrence_report_obj.observation_date
+            let vm = this;
+            if (vm.isFauna) {
+                if (vm.occurrence_report_obj && vm.occurrence_report_obj.plant_count) {
+                    vm.occurrence_report_obj.animal_observation.count_date = vm.occurrence_report_obj.observation_date
                 }
             }
-            else{
-                if(vm.occurrence_report_obj && vm.occurrence_report_obj.plant_count){
-                    vm.occurrence_report_obj.animal_observation.count_date=vm.occurrence_report_obj.observation_date
+            else {
+                if (vm.occurrence_report_obj && vm.occurrence_report_obj.plant_count) {
+                    vm.occurrence_report_obj.animal_observation.count_date = vm.occurrence_report_obj.observation_date
                 }
-            }       
+            }
         }
     },
     methods: {
+        test: function () {
+            console.log('test')
+        },
         initialiseScientificNameLookup: function () {
             let vm = this;
             $(vm.$refs[vm.scientific_name_lookup])
@@ -226,6 +234,9 @@ export default {
                     vm.occurrence_report_obj.species_id = e.params.data.species_id;
                     vm.species_display = e.params.data.text;
                     vm.taxon_previous_name = e.params.data.taxon_previous_name;
+                    // Unfortunate to call this twice but the change event on the fieldset fires before
+                    // the select2:select event
+                    vm.$emit('saveOccurrenceReport');
                 })
                 .on('select2:unselect', function (e) {
                     // eslint-disable-next-line no-unused-vars
@@ -320,9 +331,6 @@ export default {
         incrementComponentMapKey: function () {
             this.uuid = uuid();
         },
-        eventListeners: function () {
-            let vm = this;
-        },
         formatObservationDate: function () {
             if (this.occurrence_report_obj.observation_date === "") {
                 this.occurrence_report_obj.observation_date = null;
@@ -345,7 +353,6 @@ export default {
             return has_value;
         },
         generateReferralCommentBoxes: function () {
-            console.log('generateReferralCommentBoxes')
             var box_visibility =
                 this.occurrence_report_obj.assessor_mode.assessor_box_view;
             var assessor_mode =
@@ -353,10 +360,8 @@ export default {
             if (!this.occurrence_report_obj.can_user_edit) {
                 // eslint-disable-next-line no-unused-vars
                 let current_referral_present = false;
-                console.log(this.occurrence_report_obj.referrals)
 
                 $.each(this.occurrence_report_obj.referrals, (i, v) => {
-                    console.log(v)
                     var referral_name = `comment-field-Referral-${v.referral.email}`;
                     var referral_visibility =
                         assessor_mode == 'referral' &&
@@ -446,7 +451,6 @@ export default {
             vm.$refs.assessment_comments.show_warning_icon(false);
         }
         this.$nextTick(() => {
-            vm.eventListeners();
             vm.initialiseScientificNameLookup();
             vm.initialiseCommunityNameLookup();
         });

--- a/boranga/frontend/boranga/src/components/common/occurrence/ocr_documents.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/ocr_documents.vue
@@ -3,9 +3,9 @@
         <FormSection :formCollapse="false" label="Documents" Index="documents">
             <small style="color: red;"><br>(Do not upload Management or Recovery Plans here)</small>
             <form class="form-horizontal" action="index.html" method="post">
-                <div class="col-sm-12">
+                <div v-if="!isReadOnly" class="col-sm-12">
                     <div class="text-end">
-                        <button :disabled="isReadOnly" type="button" class="btn btn-primary mb-2 "
+                        <button type="button" class="btn btn-primary mb-2 "
                             @click.prevent="newDocument">
                             <i class="fa-solid fa-circle-plus"></i>
                             Add Document

--- a/boranga/frontend/boranga/src/components/common/occurrence/ocr_observation.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/ocr_observation.vue
@@ -297,6 +297,36 @@ export default {
                 id: null,
                 name: null,
             });
+
+        vm.identification_certainty_list = vm.listOfValuesDict.identification_certainty_list;
+        vm.identification_certainty_list.splice(0, 0,
+            {
+                id: null,
+                name: null,
+            });
+        vm.sample_type_list = vm.listOfValuesDict.sample_type_list;
+        vm.sample_type_list.splice(0, 0,
+            {
+                id: null,
+                name: null,
+            });
+        vm.sample_dest_list = vm.listOfValuesDict.sample_dest_list;
+        vm.sample_dest_list.splice(0, 0,
+            {
+                id: null,
+                name: null,
+            });
+        vm.permit_type_list = vm.listOfValuesDict.permit_type_list;
+        vm.permit_type_list.splice(0, 0,
+            {
+                id: null,
+                name: null,
+            });
+    },
+    mounted: function () {
+        let vm = this;
+        vm.eventListeners();
+
         if (this.isFlora) {
             // using child refs to assign the list values to avoid calling the above api again in plantCount component
             vm.$refs.plantCountDetail.plant_count_method_list = vm.listOfValuesDict.plant_count_method_list;
@@ -357,34 +387,6 @@ export default {
                     name: null,
                 });
         }
-        vm.identification_certainty_list = vm.listOfValuesDict.identification_certainty_list;
-        vm.identification_certainty_list.splice(0, 0,
-            {
-                id: null,
-                name: null,
-            });
-        vm.sample_type_list = vm.listOfValuesDict.sample_type_list;
-        vm.sample_type_list.splice(0, 0,
-            {
-                id: null,
-                name: null,
-            });
-        vm.sample_dest_list = vm.listOfValuesDict.sample_dest_list;
-        vm.sample_dest_list.splice(0, 0,
-            {
-                id: null,
-                name: null,
-            });
-        vm.permit_type_list = vm.listOfValuesDict.permit_type_list;
-        vm.permit_type_list.splice(0, 0,
-            {
-                id: null,
-                name: null,
-            });
-    },
-    mounted: function () {
-        let vm = this;
-        vm.eventListeners();
     },
 }
 </script>

--- a/boranga/frontend/boranga/src/components/common/occurrence/ocr_observation.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/ocr_observation.vue
@@ -43,7 +43,7 @@
             <PlantCount v-if="isFlora" :plant_count="occurrence_report_obj.plant_count"
                 :processing_status="occurrence_report_obj.processing_status" :is_report=true
                 :occurrence_id="occurrence_report_obj.id" id="plantCountDetail" :is_external="is_external"
-                :isReadOnly="isReadOnly" ref="plantCountDetail">
+                :isReadOnly="isReadOnly" ref="plantCountDetail" @mounted="populatePlantCountLookups">
             </PlantCount>
         </FormSection>
 
@@ -51,7 +51,7 @@
             <AnimalObservation v-if="isFauna" :animal_observation="occurrence_report_obj.animal_observation"
                 :processing_status="occurrence_report_obj.processing_status" :is_report=true
                 :occurrence_id="occurrence_report_obj.id" id="animalObservationDetail" :is_external="is_external"
-                :isReadOnly="isReadOnly" ref="animalObservationDetail">
+                :isReadOnly="isReadOnly" ref="animalObservationDetail" @mounted="populateAnimalObservationLookups">
             </AnimalObservation>
         </FormSection>
 
@@ -285,6 +285,66 @@ export default {
                 vm.updatingIdentificationDetails = false;
             });
         },
+        populatePlantCountLookups: function () {
+            // using child refs to assign the list values to avoid calling the above api again in plantCount component
+            vm.$refs.plantCountDetail.plant_count_method_list = vm.listOfValuesDict.plant_count_method_list;
+            vm.$refs.plantCountDetail.plant_count_method_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+            vm.$refs.plantCountDetail.plant_count_accuracy_list = vm.listOfValuesDict.plant_count_accuracy_list;
+            vm.$refs.plantCountDetail.plant_count_accuracy_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+            vm.$refs.plantCountDetail.plant_condition_list = vm.listOfValuesDict.plant_condition_list;
+            vm.$refs.plantCountDetail.plant_condition_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+            vm.$refs.plantCountDetail.counted_subject_list = vm.listOfValuesDict.counted_subject_list;
+            vm.$refs.plantCountDetail.counted_subject_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+        },
+        populateAnimalObservationLookups: function () {
+            // using child refs to assign the list values to avoid calling the above api again in AnimalObservation component
+            vm.$refs.animalObservationDetail.primary_detection_method_list = vm.listOfValuesDict.primary_detection_method_list;
+            vm.$refs.animalObservationDetail.primary_detection_method_list.splice(0, 0,
+                {
+                    id: '',
+                    name: '',
+                });
+            vm.$refs.animalObservationDetail.secondary_sign_list = vm.listOfValuesDict.secondary_sign_list;
+            vm.$refs.animalObservationDetail.secondary_sign_list.splice(0, 0,
+                {
+                    id: '',
+                    name: '',
+                });
+            vm.$refs.animalObservationDetail.reprod_state_list = vm.listOfValuesDict.reprod_state_list;
+            vm.$refs.animalObservationDetail.reprod_state_list.splice(0, 0,
+                {
+                    id: '',
+                    name: '',
+                });
+            vm.$refs.animalObservationDetail.death_reason_list = vm.listOfValuesDict.death_reason_list;
+            vm.$refs.animalObservationDetail.death_reason_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+            vm.$refs.animalObservationDetail.animal_health_list = vm.listOfValuesDict.animal_health_list;
+            vm.$refs.animalObservationDetail.animal_health_list.splice(0, 0,
+                {
+                    id: null,
+                    name: null,
+                });
+        }
     },
     created: async function () {
         let vm = this;
@@ -326,67 +386,6 @@ export default {
     mounted: function () {
         let vm = this;
         vm.eventListeners();
-
-        if (this.isFlora) {
-            // using child refs to assign the list values to avoid calling the above api again in plantCount component
-            vm.$refs.plantCountDetail.plant_count_method_list = vm.listOfValuesDict.plant_count_method_list;
-            vm.$refs.plantCountDetail.plant_count_method_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-            vm.$refs.plantCountDetail.plant_count_accuracy_list = vm.listOfValuesDict.plant_count_accuracy_list;
-            vm.$refs.plantCountDetail.plant_count_accuracy_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-            vm.$refs.plantCountDetail.plant_condition_list = vm.listOfValuesDict.plant_condition_list;
-            vm.$refs.plantCountDetail.plant_condition_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-            vm.$refs.plantCountDetail.counted_subject_list = vm.listOfValuesDict.counted_subject_list;
-            vm.$refs.plantCountDetail.counted_subject_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-        }
-        else if (this.isFauna) {
-            // using child refs to assign the list values to avoid calling the above api again in AnimalObservation component
-            vm.$refs.animalObservationDetail.primary_detection_method_list = vm.listOfValuesDict.primary_detection_method_list;
-            vm.$refs.animalObservationDetail.primary_detection_method_list.splice(0, 0,
-                {
-                    id: '',
-                    name: '',
-                });
-            vm.$refs.animalObservationDetail.secondary_sign_list = vm.listOfValuesDict.secondary_sign_list;
-            vm.$refs.animalObservationDetail.secondary_sign_list.splice(0, 0,
-                {
-                    id: '',
-                    name: '',
-                });
-            vm.$refs.animalObservationDetail.reprod_state_list = vm.listOfValuesDict.reprod_state_list;
-            vm.$refs.animalObservationDetail.reprod_state_list.splice(0, 0,
-                {
-                    id: '',
-                    name: '',
-                });
-            vm.$refs.animalObservationDetail.death_reason_list = vm.listOfValuesDict.death_reason_list;
-            vm.$refs.animalObservationDetail.death_reason_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-            vm.$refs.animalObservationDetail.animal_health_list = vm.listOfValuesDict.animal_health_list;
-            vm.$refs.animalObservationDetail.animal_health_list.splice(0, 0,
-                {
-                    id: null,
-                    name: null,
-                });
-        }
     },
 }
 </script>

--- a/boranga/frontend/boranga/src/components/common/occurrence/ocr_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/ocr_threats.vue
@@ -576,7 +576,7 @@ export default {
             this.$refs.threats_datatable.vmDataTable.ajax.reload();
         },
         adjust_table_width: function () {
-            this.$refs.threats_datatable.vmDataTable.columns.adjust().responsive.recalc();
+            if (this.$refs.threats_datatable !== undefined) { this.$refs.threats_datatable.vmDataTable.columns.adjust().responsive.recalc() };
         },
     },
     mounted: function () {

--- a/boranga/frontend/boranga/src/components/common/species_communities/basic_conservation_status.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/basic_conservation_status.vue
@@ -11,7 +11,6 @@
                             class="bi bi-box-arrow-up-right ps-2"></i></a>
                 </div>
             </div>
-            </div>
             <fieldset disabled>
                 <div class="row mb-3" v-if="conservation_status.wa_legislative_list">
                     <label for="wa_legislative_list" class="col-sm-4 col-form-label">WA Legislative List</label>

--- a/boranga/frontend/boranga/src/components/common/species_communities/community_profile.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/community_profile.vue
@@ -2,43 +2,43 @@
     <div id="community">
         <FormSection :formCollapse="false" label="Taxonomy" Index="taxonomy">
             <div class="row mb-3">
-                <label for="" class="col-sm-3 control-label fw-bold">Community Name: <span
-                        class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 control-label" :class="isReadOnly ? '' : 'fw-bold'">Community Name: <span
+                        v-if="!isReadOnly" class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <textarea :disabled="isReadOnly" class="form-control" rows="1" id="community_name" placeholder=""
                         v-model="species_community.taxonomy_details.community_name" />
                 </div>
             </div>
             <div class="row mb-3">
-                <label for="" class="col-sm-3 control-label fw-bold">Community ID: <span
-                        class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 control-label" :class="isReadOnly ? '' : 'fw-bold'">Community ID: <span
+                        v-if="!isReadOnly" class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <input :disabled="isReadOnly" type="text" class="form-control" id="community_migrated_id"
                         placeholder="" v-model="species_community.taxonomy_details.community_migrated_id" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(species_community.taxonomy_details.community_description)" class="row mb-3">
                 <label for="" class="col-sm-3 control-label">Community Description:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="isReadOnly" class="form-control" rows="2" id="community_description"
                         placeholder="" v-model="species_community.taxonomy_details.community_description" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(species_community.taxonomy_details.previous_name)" class="row mb-3">
                 <label for="" class="col-sm-3 control-label">Previous Name:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="isReadOnly" class="form-control" id="community_previous_name" placeholder=""
                         v-model="species_community.taxonomy_details.previous_name" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(species_community.taxonomy_details.name_authority)" class="row mb-3">
                 <label for="" class="col-sm-3 control-label">Name Authority:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="isReadOnly" rows="1" class="form-control" id="name_authority" placeholder=""
                         v-model="species_community.taxonomy_details.name_authority" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(species_community.taxonomy_details.name_comments)" class="row mb-3">
                 <label for="" class="col-sm-3 control-label">Name Comments:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="isReadOnly" class="form-control" id="community_comment" placeholder=""
@@ -49,15 +49,16 @@
         <FormSection v-if="distribution_public || is_internal" :formCollapse="false" label="Distribution"
             Index="distribution">
             <div class="row mb-3">
-                <label for="" class="col-sm-3 control-label fw-bold">Distribution: <span
-                        class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 control-label" :class="isReadOnly ? '' : 'fw-bold'">Distribution: <span
+                        v-if="!isReadOnly" class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <textarea :disabled="isReadOnly" class="form-control" rows="1" id="distribution" placeholder=""
                         v-model="species_community.distribution.distribution" />
                 </div>
             </div>
             <div class="row mb-3">
-                <label for="" class="col-sm-3 control-label fw-bold">Region: <span class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 control-label" :class="isReadOnly ? '' : 'fw-bold'">Region: <span
+                        v-if="!isReadOnly" class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <select :disabled="isReadOnly" class="form-select" v-model="species_community.regions"
                         ref="regions_select">
@@ -69,8 +70,8 @@
                 </div>
             </div>
             <div v-if="species_community.regions" class="row mb-3">
-                <label for="" class="col-sm-3 col-form-label fw-bold">District: <span
-                        class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 col-form-label" :class="isReadOnly ? '' : 'fw-bold'">District: <span
+                        v-if="!isReadOnly" class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <select :disabled="isReadOnly" class="form-select" v-model="species_community.districts"
                         ref="districts_select">
@@ -81,116 +82,121 @@
                     </select>
                 </div>
             </div>
-            <div class="row mb-3 border-top pt-3">
-                <label for="" class="col-sm-5 col-form-label">Number of Occurrences:</label>
-                <div class="col-sm-4">
-                    <input v-if="species_community.distribution.noo_auto" :disabled="isNOOReadOnly" type="number"
-                        class="form-control" id="no_of_occurrences" placeholder=""
-                        v-model="species_community.occurrence_count" />
-                    <input v-else :disabled="isNOOReadOnly" type="number" class="form-control" id="no_of_occurrences"
-                        placeholder="" ref="number_of_occurrences"
-                        v-model="species_community.distribution.number_of_occurrences" />
-                </div>
-                <div class="col-sm-3 d-flex align-items-center">
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input" id="noo_auto"
-                            @click="switchNOO('true')" v-model="species_community.distribution.noo_auto">
-                        <label class="form-check-label">auto</label>
+            <template v-if="show_calculated_distribution_fields">
+                <div class="row mb-3 border-top pt-3">
+                    <label for="" class="col-sm-5 col-form-label">Number of Occurrences:</label>
+                    <div class="col-sm-4">
+                        <input v-if="species_community.distribution.noo_auto" :disabled="isNOOReadOnly" type="number"
+                            class="form-control" id="no_of_occurrences" placeholder=""
+                            v-model="species_community.occurrence_count" />
+                        <input v-else :disabled="isNOOReadOnly" type="number" class="form-control"
+                            id="no_of_occurrences" placeholder="" ref="number_of_occurrences"
+                            v-model="species_community.distribution.number_of_occurrences" />
                     </div>
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="false" @click="switchNOO('false')"
-                            class="form-check-input" id="noo_manual" v-model="species_community.distribution.noo_auto">
-                        <label class="form-check-label">manual</label>
-                    </div>
-                </div>
-            </div>
-            <div class="row mb-3">
-                <label for="" class="col-sm-5 col-form-label">Extent of Occurrences: <i
-                        v-if="species_community.distribution.eoo_auto" class="bi bi-info-circle-fill text-primary"
-                        data-bs-toggle="popover" data-bs-trigger="hover focus"
-                        data-bs-content="Calculated by creating a 'convex hull' from all occurrence geometries for this species."></i></label>
-                <div class="col-sm-4">
-                    <div class="input-group">
-                        <input v-if="species_community.distribution.eoo_auto" :disabled="isEOOReadOnly" type="number"
-                            class="form-control" id="extent_of_occurrence" placeholder=""
-                            v-model="species_community.area_occurrence_convex_hull_km2" />
-                        <input v-else :disabled="isEOOReadOnly" type="number" class="form-control"
-                            id="extent_of_occurrence" ref="extent_of_occurrence" placeholder=""
-                            v-model="species_community.distribution.extent_of_occurrences" />
-                        <span class="input-group-text" id="area_of_occupancy_km2-addon">km&#xb2;</span>
+                    <div v-if="!isReadOnly" class="col-sm-3 d-flex align-items-center">
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input"
+                                id="noo_auto" @click="switchNOO('true')"
+                                v-model="species_community.distribution.noo_auto">
+                            <label class="form-check-label">auto</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="false" @click="switchNOO('false')"
+                                class="form-check-input" id="noo_manual"
+                                v-model="species_community.distribution.noo_auto">
+                            <label class="form-check-label">manual</label>
+                        </div>
                     </div>
                 </div>
-                <div class="col-sm-3 d-flex align-items-center">
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input" id="eoo_auto"
-                            @click="switchEOO('true')" v-model="species_community.distribution.eoo_auto">
-                        <label class="form-check-label">auto</label>
+                <div class="row mb-3">
+                    <label for="" class="col-sm-5 col-form-label">Extent of Occurrences: <i
+                            v-if="species_community.distribution.eoo_auto" class="bi bi-info-circle-fill text-primary"
+                            data-bs-toggle="popover" data-bs-trigger="hover focus"
+                            data-bs-content="Calculated by creating a 'convex hull' from all occurrence geometries for this species."></i></label>
+                    <div class="col-sm-4">
+                        <div class="input-group">
+                            <input v-if="species_community.distribution.eoo_auto" :disabled="isEOOReadOnly"
+                                type="number" class="form-control" id="extent_of_occurrence" placeholder=""
+                                v-model="species_community.area_occurrence_convex_hull_km2" />
+                            <input v-else :disabled="isEOOReadOnly" type="number" class="form-control"
+                                id="extent_of_occurrence" ref="extent_of_occurrence" placeholder=""
+                                v-model="species_community.distribution.extent_of_occurrences" />
+                            <span class="input-group-text" id="area_of_occupancy_km2-addon">km&#xb2;</span>
+                        </div>
                     </div>
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="false" class="form-check-input"
-                            id="eoo_manual" @click="switchEOO('false')"
-                            v-model="species_community.distribution.eoo_auto">
-                        <label class="form-check-label">manual</label>
-                    </div>
-                </div>
-            </div>
-            <div class="row mb-3">
-                <label for="" class="col-sm-5 col-form-label">Area of Occupancy:</label>
-                <div class="col-sm-4">
-                    <div class="input-group">
-                        <input :disabled="isReadOnly" type="number" class="form-control" id="area_of_occupany"
-                            placeholder="" v-model="species_community.distribution.area_of_occupancy" />
-                        <span class="input-group-text" id="area_of_occupancy-addon">2km x 2km</span>
-                    </div>
-                </div>
-            </div>
-            <div class="row mb-3">
-                <label for="" class="col-sm-5 col-form-label">Actual Area of Occupancy: <i
-                        v-if="species_community.distribution.aoo_actual_auto"
-                        class="bi bi-info-circle-fill text-primary" data-bs-toggle="popover"
-                        data-bs-trigger="hover focus"
-                        data-bs-content="Calculated by combining the total land area of all occurrence geometries for this species."></i></label>
-                <div class="col-sm-4">
-                    <div class="input-group">
-                        <input v-if="species_community.distribution.aoo_actual_auto" :disabled="isAOOActualReadOnly"
-                            type="number" step="any" class="form-control" id="area_of_occupancy_actual" placeholder=""
-                            v-model="species_community.area_of_occupancy_km2" area-describedby="" />
-                        <input v-else :disabled="isAOOActualReadOnly" type="number" step="any" class="form-control"
-                            id="area_of_occupancy_actual" ref="area_of_occupancy_actual" placeholder=""
-                            v-model="species_community.distribution.area_of_occupancy_actual" />
-                        <span class="input-group-text" id="area_of_occupancy_km2-addon">km&#xb2;</span>
+                    <div v-if="!isReadOnly" class="col-sm-3 d-flex align-items-center">
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input"
+                                id="eoo_auto" @click="switchEOO('true')"
+                                v-model="species_community.distribution.eoo_auto">
+                            <label class="form-check-label">auto</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="false" class="form-check-input"
+                                id="eoo_manual" @click="switchEOO('false')"
+                                v-model="species_community.distribution.eoo_auto">
+                            <label class="form-check-label">manual</label>
+                        </div>
                     </div>
                 </div>
-                <div class="col-sm-3 d-flex align-items-center">
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input"
-                            id="aoo_actual_auto" @click="switchAOOActual('true')"
-                            v-model="species_community.distribution.aoo_actual_auto">
-                        <label class="form-check-label">auto</label>
-                    </div>
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="false" class="form-check-input"
-                            id="aoo_actual_manual" @click="switchAOOActual('false')"
-                            v-model="species_community.distribution.aoo_actual_auto">
-                        <label class="form-check-label">manual</label>
+                <div class="row mb-3">
+                    <label for="" class="col-sm-5 col-form-label">Area of Occupancy:</label>
+                    <div class="col-sm-4">
+                        <div class="input-group">
+                            <input :disabled="isReadOnly" type="number" class="form-control" id="area_of_occupany"
+                                placeholder="" v-model="species_community.distribution.area_of_occupancy" />
+                            <span class="input-group-text" id="area_of_occupancy-addon">2km x 2km</span>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div class="row mb-3">
+                <div class="row mb-3">
+                    <label for="" class="col-sm-5 col-form-label">Actual Area of Occupancy: <i
+                            v-if="species_community.distribution.aoo_actual_auto"
+                            class="bi bi-info-circle-fill text-primary" data-bs-toggle="popover"
+                            data-bs-trigger="hover focus"
+                            data-bs-content="Calculated by combining the total land area of all occurrence geometries for this species."></i></label>
+                    <div class="col-sm-4">
+                        <div class="input-group">
+                            <input v-if="species_community.distribution.aoo_actual_auto" :disabled="isAOOActualReadOnly"
+                                type="number" step="any" class="form-control" id="area_of_occupancy_actual"
+                                placeholder="" v-model="species_community.area_of_occupancy_km2" area-describedby="" />
+                            <input v-else :disabled="isAOOActualReadOnly" type="number" step="any" class="form-control"
+                                id="area_of_occupancy_actual" ref="area_of_occupancy_actual" placeholder=""
+                                v-model="species_community.distribution.area_of_occupancy_actual" />
+                            <span class="input-group-text" id="area_of_occupancy_km2-addon">km&#xb2;</span>
+                        </div>
+                    </div>
+                    <div v-if="!isReadOnly" class="col-sm-3 d-flex align-items-center">
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input"
+                                id="aoo_actual_auto" @click="switchAOOActual('true')"
+                                v-model="species_community.distribution.aoo_actual_auto">
+                            <label class="form-check-label">auto</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="false" class="form-check-input"
+                                id="aoo_actual_manual" @click="switchAOOActual('false')"
+                                v-model="species_community.distribution.aoo_actual_auto">
+                            <label class="form-check-label">manual</label>
+                        </div>
+                    </div>
+                </div>
+            </template>
+            <div v-if="showField(species_community.distribution.number_of_iucn_locations)" class="row mb-3">
                 <label for="" class="col-sm-5 control-label">Number of IUCN Locations:</label>
                 <div class="col-sm-4">
                     <input :disabled="isReadOnly" type="number" class="form-control" id="no_of_iucn_locations"
                         placeholder="" v-model="species_community.distribution.number_of_iucn_locations" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(species_community.distribution.community_original_area)" class="row mb-3">
                 <label for="" class="col-sm-5 control-label">Community Original Area (ha):</label>
                 <div class="col-sm-4">
                     <input :disabled="isReadOnly" type="number" class="form-control" id="community_original_area"
                         placeholder="" v-model="species_community.distribution.community_original_area" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(species_community.distribution.community_original_area_accuracy)" class="row mb-3">
                 <label for="" class="col-sm-5 control-label">Community Original Area (+/- ha) Accuracy:</label>
                 <div class="col-sm-4">
                     <input :disabled="isReadOnly" type="number" class="form-control"
@@ -198,7 +204,7 @@
                         v-model="species_community.distribution.community_original_area_accuracy" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(species_community.distribution.community_original_area_reference)" class="row mb-3">
                 <label for="" class="col-sm-5 control-label">Community Original Area (ha) Reference:</label>
                 <div class="col-sm-4">
                     <input :disabled="isReadOnly" type="text" class="form-control"
@@ -564,7 +570,11 @@ export default {
             else {
                 return ""
             }
-        }
+        },
+        show_calculated_distribution_fields: function () {
+            return this.is_internal || (this.species_community.distribution.noo_auto && this.species_community.occurrence_count > 0
+                || !this.species_community.distribution.noo_auto && this.species_community.distribution.number_of_occurrences > 0)
+        },
     },
     watch: {
         "species_community.distribution.number_of_iucn_locations": function (newVal) {
@@ -593,6 +603,12 @@ export default {
         },
     },
     methods: {
+        showField(fieldValue) {
+            if (!this.isReadOnly) {
+                return true
+            }
+            return this.isReadOnly && fieldValue;
+        },
         updatePublishing(data) {
             let vm = this;
             vm.$http.post(helpers.add_endpoint_json(api_endpoints.community, (vm.species_community.id + '/update_publishing_status')), data, {

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_profile.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_profile.vue
@@ -2,20 +2,23 @@
     <div id="species">
         <FormSection :formCollapse="false" label="Taxonomy" :Index="taxonBody">
             <div class="row mb-3">
-                <label for="" class="col-sm-3 col-form-label fw-bold">Scientific Name: <span
-                        class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 col-form-label"
+                    :class="(rename_species || !isReadOnly) ? 'fw-bold' : ''">Scientific Name: <span
+                        v-if="rename_species || !isReadOnly" class="text-danger">*</span></label>
                 <div class="col-sm-9" :id="select_scientific_name">
-                    <select :disabled="rename_species ? false : isReadOnly" :id="scientific_name_lookup"
+                    <select v-if="rename_species || !isReadOnly" :id="scientific_name_lookup"
                         :name="scientific_name_lookup" :ref="scientific_name_lookup" class="form-select" />
+                    <input v-else :disabled="true" type="text" class="form-control" id="taxon_name_id" placeholder=""
+                        v-model="species_community.scientific_name" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="species_community.scientific_name != species_display" class="row mb-3">
                 <label for="" class="col-sm-3 col-form-label"></label>
                 <div class="col-sm-9">
                     <textarea disabled class="form-control" rows=2 id="species_display" v-model="species_display" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(common_name)" class="row mb-3">
                 <label for="" class="col-sm-3 col-form-label">Common Name:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="true" class="form-control" rows="2" id="common_name" placeholder=""
@@ -29,42 +32,42 @@
                         v-model="taxon_name_id" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(taxon_previous_name)" class="row mb-3">
                 <label for="" class="col-sm-3 col-form-label">Previous Name:</label>
                 <div class="col-sm-9">
                     <input :disabled="true" type="text" class="form-control" id="previous_name" placeholder=""
                         v-model="taxon_previous_name" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(phylogenetic_group)" class="row mb-3">
                 <label for="" class="col-sm-3 col-form-label">Phylogenetic Group:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="true" class="form-control" rows="1" id="phylogenetic_group" placeholder=""
                         v-model="phylogenetic_group" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(family)" class="row mb-3">
                 <label for="" class="col-sm-3 col-form-label">Family:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="true" rows="1" class="form-control" id="family" placeholder=""
                         v-model="family" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(genus)" class="row mb-3">
                 <label for="" class="col-sm-3 col-form-label">Genus:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="true" rows="1" class="form-control" id="genus" placeholder=""
                         v-model="genus" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(name_authority)" class="row mb-3">
                 <label for="" class="col-sm-3 col-form-label">Name Authority:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="true" rows="1" class="form-control" id="name_authority" placeholder=""
                         v-model="name_authority" />
                 </div>
             </div>
-            <div class="row mb-3">
+            <div v-if="showField(name_comments)" class="row mb-3">
                 <label for="" class="col-sm-3 col-form-label">NOMOS names comments:</label>
                 <div class="col-sm-9">
                     <textarea :disabled="true" class="form-control" rows="3" id="name_comments" placeholder=""
@@ -75,15 +78,16 @@
         <FormSection v-if="distribution_public || is_internal" :formCollapse="false" label="Distribution"
             :Index="distributionBody">
             <div class="row mb-3">
-                <label for="" class="col-sm-3 col-form-label fw-bold">Distribution: <span
-                        class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 col-form-label" :class="isReadOnly ? '' : 'fw-bold'">Distribution: <span
+                        v-if="!isReadOnly" class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <textarea :disabled="isReadOnly" class="form-control" rows="1" id="distribution" placeholder=""
                         v-model="species_community.distribution.distribution" />
                 </div>
             </div>
             <div class="row mb-3">
-                <label for="" class="col-sm-3 col-form-label fw-bold">Region: <span class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 col-form-label" :class="isReadOnly ? '' : 'fw-bold'">Region: <span
+                        v-if="!isReadOnly" class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <select :disabled="isReadOnly" class="form-select" v-model="species_community.regions"
                         ref="regions_select">
@@ -95,8 +99,8 @@
                 </div>
             </div>
             <div v-if="species_community.regions" class="row mb-3">
-                <label for="" class="col-sm-3 col-form-label fw-bold">District: <span
-                        class="text-danger">*</span></label>
+                <label for="" class="col-sm-3 col-form-label" :class="isReadOnly ? '' : 'fw-bold'">District: <span
+                        v-if="!isReadOnly" class="text-danger">*</span></label>
                 <div class="col-sm-9">
                     <select :disabled="isReadOnly" class="form-select" v-model="species_community.districts"
                         ref="districts_select">
@@ -107,109 +111,114 @@
                     </select>
                 </div>
             </div>
-            <div class="row mb-3 border-top pt-3">
-                <label for="" class="col-sm-4 col-form-label">Number of Occurrences:</label>
-                <div class="col-sm-4">
-                    <input v-if="species_community.distribution.noo_auto" :disabled="isNOOReadOnly" type="number"
-                        class="form-control" id="no_of_occurrences" placeholder=""
-                        v-model="species_community.occurrence_count" />
-                    <input v-else :disabled="isNOOReadOnly" type="number" class="form-control" id="no_of_occurrences"
-                        placeholder="" ref="number_of_occurrences"
-                        v-model="species_community.distribution.number_of_occurrences" />
-                </div>
-                <div class="col-sm-3 d-flex align-items-center">
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input" id="noo_auto"
-                            @click="switchNOO('true')" v-model="species_community.distribution.noo_auto">
-                        <label class="form-check-label">auto</label>
+            <template v-if="show_calculated_distribution_fields">
+                <div class="row mb-3 pt-3">
+                    <label for="" class="col-sm-4 col-form-label">Number of Occurrences:</label>
+                    <div v-if="showField(species_community.distribution.number_of_occurrences)" class="col-sm-4">
+                        <input v-if="species_community.distribution.noo_auto" :disabled="isNOOReadOnly" type="number"
+                            class="form-control" id="no_of_occurrences" placeholder=""
+                            v-model="species_community.occurrence_count" />
+                        <input v-else :disabled="isNOOReadOnly" type="number" class="form-control"
+                            id="no_of_occurrences" placeholder="" ref="number_of_occurrences"
+                            v-model="species_community.distribution.number_of_occurrences" />
                     </div>
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="false" @click="switchNOO('false')"
-                            class="form-check-input" id="noo_manual" v-model="species_community.distribution.noo_auto">
-                        <label class="form-check-label">manual</label>
-                    </div>
-                </div>
-            </div>
-            <div class="row mb-3">
-                <label for="" class="col-sm-4 col-form-label">Extent of Occurrences: <i
-                        v-if="species_community.distribution.eoo_auto" class="bi bi-info-circle-fill text-primary"
-                        data-bs-toggle="popover" data-bs-trigger="hover focus"
-                        data-bs-content="Calculated by creating a 'convex hull' from all occurrence geometries for this species."></i></label>
-                <div class="col-sm-4">
-                    <div class="input-group">
-                        <input v-if="species_community.distribution.eoo_auto" :disabled="isEOOReadOnly" type="number"
-                            class="form-control" id="extent_of_occurrence" placeholder=""
-                            v-model="species_community.area_occurrence_convex_hull_km2" />
-                        <input v-else :disabled="isEOOReadOnly" type="number" class="form-control"
-                            id="extent_of_occurrence" ref="extent_of_occurrence" placeholder=""
-                            v-model="species_community.distribution.extent_of_occurrences" />
-                        <span class="input-group-text" id="area_of_occupancy_km2-addon">km&#xb2;</span>
+                    <div v-if="!isReadOnly" class="col-sm-3 d-flex align-items-center">
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input"
+                                id="noo_auto" @click="switchNOO('true')"
+                                v-model="species_community.distribution.noo_auto">
+                            <label class="form-check-label">auto</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="false" @click="switchNOO('false')"
+                                class="form-check-input" id="noo_manual"
+                                v-model="species_community.distribution.noo_auto">
+                            <label class="form-check-label">manual</label>
+                        </div>
                     </div>
                 </div>
-                <div class="col-sm-3 d-flex align-items-center">
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input" id="eoo_auto"
-                            @click="switchEOO('true')" v-model="species_community.distribution.eoo_auto">
-                        <label class="form-check-label">auto</label>
+                <div class="row mb-3">
+                    <label for="" class="col-sm-4 col-form-label">Extent of Occurrences: <i
+                            v-if="species_community.distribution.eoo_auto" class="bi bi-info-circle-fill text-primary"
+                            data-bs-toggle="popover" data-bs-trigger="hover focus"
+                            data-bs-content="Calculated by creating a 'convex hull' from all occurrence geometries for this species."></i></label>
+                    <div class="col-sm-4">
+                        <div class="input-group">
+                            <input v-if="species_community.distribution.eoo_auto" :disabled="isEOOReadOnly"
+                                type="number" class="form-control" id="extent_of_occurrence" placeholder=""
+                                v-model="species_community.area_occurrence_convex_hull_km2" />
+                            <input v-else :disabled="isEOOReadOnly" type="number" class="form-control"
+                                id="extent_of_occurrence" ref="extent_of_occurrence" placeholder=""
+                                v-model="species_community.distribution.extent_of_occurrences" />
+                            <span class="input-group-text" id="area_of_occupancy_km2-addon">km&#xb2;</span>
+                        </div>
                     </div>
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="false" class="form-check-input"
-                            id="eoo_manual" @click="switchEOO('false')"
-                            v-model="species_community.distribution.eoo_auto">
-                        <label class="form-check-label">manual</label>
-                    </div>
-                </div>
-            </div>
-            <div class="row mb-3">
-                <label for="" class="col-sm-4 col-form-label">Area of Occupancy:</label>
-                <div class="col-sm-4">
-                    <div class="input-group">
-                        <input :disabled="isReadOnly" type="number" class="form-control" id="area_of_occupany"
-                            placeholder="" v-model="species_community.distribution.area_of_occupancy" />
-                        <span class="input-group-text" id="area_of_occupancy-addon">2km x 2km</span>
-                    </div>
-                </div>
-            </div>
-            <div class="row mb-3">
-                <label for="" class="col-sm-4 col-form-label">Actual Area of Occupancy: <i
-                        v-if="species_community.distribution.aoo_actual_auto"
-                        class="bi bi-info-circle-fill text-primary" data-bs-toggle="popover"
-                        data-bs-trigger="hover focus"
-                        data-bs-content="Calculated by combining the total land area of all occurrence geometries for this species."></i></label>
-                <div class="col-sm-4">
-                    <div class="input-group">
-                        <input v-if="species_community.distribution.aoo_actual_auto" :disabled="isAOOActualReadOnly"
-                            type="number" step="any" class="form-control" id="area_of_occupancy_actual" placeholder=""
-                            v-model="species_community.area_of_occupancy_km2" area-describedby="" />
-                        <input v-else :disabled="isAOOActualReadOnly" type="number" step="any" class="form-control"
-                            id="area_of_occupancy_actual" ref="area_of_occupancy_actual" placeholder=""
-                            v-model="species_community.distribution.area_of_occupancy_actual" />
-                        <span class="input-group-text" id="area_of_occupancy_km2-addon">km&#xb2;</span>
+                    <div v-if="!isReadOnly" class="col-sm-3 d-flex align-items-center">
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input"
+                                id="eoo_auto" @click="switchEOO('true')"
+                                v-model="species_community.distribution.eoo_auto">
+                            <label class="form-check-label">auto</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="false" class="form-check-input"
+                                id="eoo_manual" @click="switchEOO('false')"
+                                v-model="species_community.distribution.eoo_auto">
+                            <label class="form-check-label">manual</label>
+                        </div>
                     </div>
                 </div>
-                <div class="col-sm-3 d-flex align-items-center">
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input"
-                            id="aoo_actual_auto" @click="switchAOOActual('true')"
-                            v-model="species_community.distribution.aoo_actual_auto">
-                        <label class="form-check-label">auto</label>
-                    </div>
-                    <div class="form-check form-check-inline">
-                        <input :disabled="isReadOnly" type="radio" :value="false" class="form-check-input"
-                            id="aoo_actual_manual" @click="switchAOOActual('false')"
-                            v-model="species_community.distribution.aoo_actual_auto">
-                        <label class="form-check-label">manual</label>
+                <div class="row mb-3">
+                    <label for="" class="col-sm-4 col-form-label">Area of Occupancy:</label>
+                    <div class="col-sm-4">
+                        <div class="input-group">
+                            <input :disabled="isReadOnly" type="number" class="form-control" id="area_of_occupany"
+                                placeholder="" v-model="species_community.distribution.area_of_occupancy" />
+                            <span class="input-group-text" id="area_of_occupancy-addon">2km x 2km</span>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div class="row mb-3">
+                <div class="row mb-3">
+                    <label for="" class="col-sm-4 col-form-label">Actual Area of Occupancy: <i
+                            v-if="species_community.distribution.aoo_actual_auto"
+                            class="bi bi-info-circle-fill text-primary" data-bs-toggle="popover"
+                            data-bs-trigger="hover focus"
+                            data-bs-content="Calculated by combining the total land area of all occurrence geometries for this species."></i></label>
+                    <div class="col-sm-4">
+                        <div class="input-group">
+                            <input v-if="species_community.distribution.aoo_actual_auto" :disabled="isAOOActualReadOnly"
+                                type="number" step="any" class="form-control" id="area_of_occupancy_actual"
+                                placeholder="" v-model="species_community.area_of_occupancy_km2" area-describedby="" />
+                            <input v-else :disabled="isAOOActualReadOnly" type="number" step="any" class="form-control"
+                                id="area_of_occupancy_actual" ref="area_of_occupancy_actual" placeholder=""
+                                v-model="species_community.distribution.area_of_occupancy_actual" />
+                            <span class="input-group-text" id="area_of_occupancy_km2-addon">km&#xb2;</span>
+                        </div>
+                    </div>
+                    <div v-if="!isReadOnly" class="col-sm-3 d-flex align-items-center">
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="true" class="form-check-input"
+                                id="aoo_actual_auto" @click="switchAOOActual('true')"
+                                v-model="species_community.distribution.aoo_actual_auto">
+                            <label class="form-check-label">auto</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input :disabled="isReadOnly" type="radio" :value="false" class="form-check-input"
+                                id="aoo_actual_manual" @click="switchAOOActual('false')"
+                                v-model="species_community.distribution.aoo_actual_auto">
+                            <label class="form-check-label">manual</label>
+                        </div>
+                    </div>
+                </div>
+            </template>
+            <div v-if="showField(species_community.distribution.number_of_iucn_locations)" class="row mb-3">
                 <label for="" class="col-sm-4 col-form-label">Number of IUCN Locations:</label>
                 <div class="col-sm-4">
                     <input :disabled="isReadOnly" type="number" class="form-control" id="no_of_iucn_locations"
                         placeholder="" v-model="species_community.distribution.number_of_iucn_locations" />
                 </div>
             </div>
-            <div class="row mb-1">
+            <div v-if="showField(species_community.distribution.number_of_iucn_subpopulations)" class="row mb-1">
                 <label for="" class="col-sm-4 col-form-label">Number of IUCN Sub-populations:</label>
                 <div class="col-sm-4">
                     <input :disabled="isReadOnly" type="number" class="form-control" id="number_of_iucn_subpopulations"
@@ -946,7 +955,11 @@ export default {
             else {
                 return vm.isReadOnly;
             }
-        }
+        },
+        show_calculated_distribution_fields: function () {
+            return this.is_internal || (this.species_community.distribution.noo_auto && this.species_community.occurrence_count > 0
+                || !this.species_community.distribution.noo_auto && this.species_community.distribution.number_of_occurrences > 0)
+        },
     },
     watch: {
         // "species_community.distribution.eoo_auto": function(newVal) {
@@ -973,6 +986,12 @@ export default {
         },
     },
     methods: {
+        showField(fieldValue) {
+            if (!this.isReadOnly) {
+                return true
+            }
+            return this.isReadOnly && fieldValue;
+        },
         updatePublishing(data) {
             let vm = this;
             vm.$http.post(helpers.add_endpoint_json(api_endpoints.species, (vm.species_community.id + '/update_publishing_status')), data, {

--- a/boranga/frontend/boranga/src/components/external/occurrence/occurrence_report_proposal.vue
+++ b/boranga/frontend/boranga/src/components/external/occurrence/occurrence_report_proposal.vue
@@ -321,9 +321,7 @@ export default {
                 payload.action = 'submit';
             }
             const result = await vm.$http.post(vm.ocr_proposal_form_url, payload).then(res => {
-                this.$nextTick(async () => {
-                    this.$refs.occurrence_report.$refs.ocr_location.incrementComponentMapKey();
-                });
+                console.log('saved before submit');
             }, err => {
                 var errorText = helpers.apiVueResourceError(err);
                 swal.fire({
@@ -511,7 +509,7 @@ export default {
             }).then(async (swalresult) => {
                 if (swalresult.isConfirmed) {
                     /* just save and submit - no payment required (probably application was pushed back by assessor for amendment */
-                    let result = await vm.save_before_submit()
+                    await vm.save_before_submit()
                     if (!vm.saveError) {
                         let payload = new Object();
                         Object.assign(payload, vm.occurrence_report_obj);

--- a/boranga/frontend/boranga/src/components/external/occurrence/occurrence_report_proposal.vue
+++ b/boranga/frontend/boranga/src/components/external/occurrence/occurrence_report_proposal.vue
@@ -41,7 +41,7 @@
 
             <ProposalOccurrenceReport v-if="occurrence_report_obj" :occurrence_report_obj="occurrence_report_obj"
                 id="OccurrenceReportStart" :canEditStatus="canEditStatus" :is_external="true" ref="occurrence_report"
-                @refreshOccurrenceReport="refreshOccurrenceReport()" @refreshFromResponse="refreshFromResponse">
+                @refreshOccurrenceReport="refreshOccurrenceReport()" @refreshFromResponse="refreshFromResponse" @saveOccurrenceReport="save_before_submit()">
             </ProposalOccurrenceReport>
 
             <div>

--- a/boranga/frontend/boranga/src/components/external/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/external/species_communities/species_communities.vue
@@ -89,7 +89,7 @@ export default {
         },
         display_name: function () {
             return (this.species_community.group_type === "community") ?
-                (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.community_migrated_id : '' :
+                (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.community_name: '' :
                 (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.scientific_name + " (" + this.species_community.taxonomy_details.taxon_name_id + ")" : '';
         },
         image_url: function () {

--- a/boranga/frontend/boranga/src/components/external/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/external/species_communities/species_communities.vue
@@ -89,7 +89,7 @@ export default {
         },
         display_name: function () {
             return (this.species_community.group_type === "community") ?
-                (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.community_name: '' :
+                (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.community_migrated_id: '' :
                 (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.scientific_name + " (" + this.species_community.taxonomy_details.taxon_name_id + ")" : '';
         },
         image_url: function () {

--- a/boranga/frontend/boranga/src/components/form_conservation_status.vue
+++ b/boranga/frontend/boranga/src/components/form_conservation_status.vue
@@ -34,7 +34,7 @@
                         :conservation_status_obj="conservation_status_obj" :referral="referral"
                         @saveConservationStatus="$emit('saveConservationStatus');">
                     </SpeciesStatus>
-                    <CSDocuments v-if="!is_internal" :key="reloadcount + 'cs_documents'" ref="cs_documents"
+                    <CSDocuments v-if="!is_internal && !referral" :key="reloadcount + 'cs_documents'" ref="cs_documents"
                         id="csDocuments" :is_internal="is_internal" :conservation_status_obj="conservation_status_obj">
                     </CSDocuments>
                     <SubmitterInformation v-if="conservation_status_obj.submitter_information"

--- a/boranga/frontend/boranga/src/components/form_conservation_status.vue
+++ b/boranga/frontend/boranga/src/components/form_conservation_status.vue
@@ -41,7 +41,7 @@
                         :key="reloadcount + 'submitter_information'" ref="submitter_information"
                         id="submitter_information" :show_submitter_contact_details="show_submitter_contact_details"
                         :submitter_information="conservation_status_obj.submitter_information"
-                        :disabled="!conservation_status_obj.can_user_edit" />
+                        :disabled="!conservation_status_obj.can_user_edit || referral" />
                 </div>
                 <div class="tab-pane fade" :id="documentBody" role="tabpanel" aria-labelledby="pills-documents-tab">
                     <CSDocuments :key="reloadcount" ref="cs_documents" id="csDocuments" :is_internal="is_internal"

--- a/boranga/frontend/boranga/src/components/form_occurrence_report.vue
+++ b/boranga/frontend/boranga/src/components/form_occurrence_report.vue
@@ -3,7 +3,7 @@
         <div class="" :id="occurrenceReportBody">
             <OCRProfile ref="ocr_profile" id="ocrProfile" :is_external="is_external" :referral="referral"
                 :show_observer_contact_information="show_observer_contact_information"
-                :occurrence_report_obj="occurrence_report_obj" @refreshOccurrenceReport="refreshOccurrenceReport()">
+                :occurrence_report_obj="occurrence_report_obj" @refreshOccurrenceReport="refreshOccurrenceReport()" @saveOccurrenceReport="saveOccurrenceReport()">
             </OCRProfile>
             <SubmitterInformation v-if="occurrence_report_obj.submitter_information" :key="reloadcount"
                 ref="submitter_information" id="submitter_information"
@@ -125,7 +125,7 @@ export default {
             default: true,
         },
     },
-    emits: ['refreshFromResponse', 'refreshOccurrenceReport'],
+    emits: ['refreshFromResponse', 'refreshOccurrenceReport', 'saveOccurrenceReport'],
     data: function () {
         let vm = this;
         return {
@@ -180,6 +180,9 @@ export default {
         },
         refreshOccurrenceReport: function () {
             this.$emit('refreshOccurrenceReport');
+        },
+        saveOccurrenceReport: function () {
+            this.$emit('saveOccurrenceReport');
         },
     },
 };

--- a/boranga/frontend/boranga/src/components/form_occurrence_report.vue
+++ b/boranga/frontend/boranga/src/components/form_occurrence_report.vue
@@ -161,18 +161,10 @@ export default {
         vm.eventListener();
     },
     methods: {
-        //----function to resolve datatable exceeding beyond the div
-        // eslint-disable-next-line no-unused-vars
         tabClicked: function (param) {
-            this.reloadcount = this.reloadcount + 1;
-        },
-        eventListener: function () {
-            // eslint-disable-next-line no-unused-vars
-            let vm = this;
-        },
-        // eslint-disable-next-line no-unused-vars
-        refreshFromResponse: function (data) {
-            //this.$emit('refreshFromResponse', data);
+            // TODO: This was reloading the components in every tab every time someone clicked on a tab.
+            // Leaving here for now in case it was needed for an unforseen reason, if not please delete this method.
+            // this.reloadcount = this.reloadcount + 1;
         },
         refreshOccurrenceReport: function () {
             this.$emit('refreshOccurrenceReport');

--- a/boranga/frontend/boranga/src/components/form_occurrence_report.vue
+++ b/boranga/frontend/boranga/src/components/form_occurrence_report.vue
@@ -9,7 +9,7 @@
                 ref="submitter_information" id="submitter_information"
                 :show_submitter_contact_details="show_submitter_contact_details"
                 :submitter_information="occurrence_report_obj.submitter_information"
-                :disabled="!occurrence_report_obj.can_user_edit" />
+                :disabled="!occurrence_report_obj.can_user_edit || referral" />
         </div>
         <div class="col-md-12">
             <ul id="pills-tab" class="nav nav-pills" role="tablist">

--- a/boranga/frontend/boranga/src/components/form_occurrence_report.vue
+++ b/boranga/frontend/boranga/src/components/form_occurrence_report.vue
@@ -15,31 +15,31 @@
             <ul id="pills-tab" class="nav nav-pills" role="tablist">
                 <li class="nav-item">
                     <a id="pills-location-tab" class="nav-link active" data-bs-toggle="pill" :href="'#' + locationBody"
-                        role="tab" :aria-controls="locationBody" aria-selected="true" @click="tabClicked()">
+                        role="tab" :aria-controls="locationBody" aria-selected="true" @click="tabClicked('location')">
                         Location
                     </a>
                 </li>
                 <li class="nav-item">
                     <a id="pills-habitat-tab" class="nav-link" data-bs-toggle="pill" :href="'#' + habitatBody"
-                        role="tab" aria-selected="false" @click="tabClicked()">
+                        role="tab" aria-selected="false" @click="tabClicked('habitat')">
                         Habitat
                     </a>
                 </li>
                 <li class="nav-item">
                     <a id="pills-observation-tab" class="nav-link" data-bs-toggle="pill" :href="'#' + observationBody"
-                        role="tab" aria-selected="false" @click="tabClicked()">
+                        role="tab" aria-selected="false" @click="tabClicked('observation')">
                         Observation
                     </a>
                 </li>
                 <li class="nav-item">
                     <a id="pills-documents-tab" class="nav-link" data-bs-toggle="pill" :href="'#' + documentBody"
-                        role="tab" aria-selected="false" @click="tabClicked()">
+                        role="tab" aria-selected="false" @click="tabClicked('documents')">
                         Documents
                     </a>
                 </li>
                 <li class="nav-item">
                     <a id="pills-threats-tab" class="nav-link" data-bs-toggle="pill" :href="'#' + threatBody" role="tab"
-                        aria-selected="false" @click="tabClicked()">
+                        aria-selected="false" @click="tabClicked('threats')">
                         Threats
                     </a>
                 </li>
@@ -131,6 +131,7 @@ export default {
         return {
             values: null,
             reloadcount: 0,
+            threatsKey: 0,
             occurrenceReportBody: 'occurrenceReportBody' + vm._uid,
             locationBody: 'locationBody' + vm._uid,
             habitatBody: 'habitatBody' + vm._uid,
@@ -158,13 +159,24 @@ export default {
     mounted: function () {
         let vm = this;
         vm.form = document.forms.new_occurrence_report;
-        vm.eventListener();
+        document.querySelectorAll('a[data-bs-toggle="pill"]').forEach((el) => {
+            el.addEventListener('shown.bs.tab', () => {
+                if (el.id == 'pills-threats-tab') {
+                    this.$refs.ocr_threats.adjust_table_width();
+                } else if (el.id == 'pills-documents-tab') {
+                    this.$refs.ocr_documents.adjust_table_width();
+                }
+            });
+        });
     },
     methods: {
         tabClicked: function (param) {
             // TODO: This was reloading the components in every tab every time someone clicked on a tab.
             // Leaving here for now in case it was needed for an unforseen reason, if not please delete this method.
             // this.reloadcount = this.reloadcount + 1;
+        },
+        refreshFromResponse: function () {
+            this.$emit('refreshFromResponse');
         },
         refreshOccurrenceReport: function () {
             this.$emit('refreshOccurrenceReport');

--- a/boranga/frontend/boranga/src/components/form_species_communities.vue
+++ b/boranga/frontend/boranga/src/components/form_species_communities.vue
@@ -43,7 +43,7 @@
                         id="communityDocuments" :is_internal="is_internal" :species_community="species_community"
                         :is_readonly="is_readonly">
                     </CommunityDocuments>
-                    <SpeciesDocuments v-else :key="reloadcount" ref="species_documents" id="speciesDocuments"
+                    <SpeciesDocuments v-else :key="`${reloadcount}-else`" ref="species_documents" id="speciesDocuments"
                         :is_internal="is_internal" :species_community="species_community" :is_readonly="is_readonly">
                     </SpeciesDocuments>
                 </div>
@@ -52,7 +52,7 @@
                         id="communityThreats" :is_internal="is_internal" :species_community="species_community"
                         :is_readonly="is_readonly">
                     </CommunityThreats>
-                    <SpeciesThreats v-else :key="reloadcount" ref="species_threats" id="speciesThreats"
+                    <SpeciesThreats v-else :key="`${reloadcount}-else`" ref="species_threats" id="speciesThreats"
                         :is_internal="is_internal" :species_community="species_community" :is_readonly="is_readonly">
                     </SpeciesThreats>
                 </div>
@@ -160,32 +160,18 @@ export default {
         },
     },
     methods: {
-        //----function to resolve datatable exceeding beyond the div
         tabClicked: function (param) {
             this.reloadcount = this.reloadcount + 1;
         },
-        /*set_tabs:function(){
-            let vm = this;
-
-             set profile tab Active
-            //$('#pills-tab a[href="#pills-profile"]').tab('show');
-        },*/
         refreshSpeciesCommunity: function() {
             let vm = this;
             vm.$parent.refreshSpeciesCommunity();
         },
-        eventListener: function () {
-            let vm = this;
-        },
-
     },
     mounted: function () {
         let vm = this;
-        //vm.set_tabs();
         vm.form = document.forms.new_species;
-        vm.eventListener();
     }
-
 }
 </script>
 

--- a/boranga/frontend/boranga/src/components/internal/conservation_status/referral.vue
+++ b/boranga/frontend/boranga/src/components/internal/conservation_status/referral.vue
@@ -64,8 +64,9 @@
                             <div class="row">
                                 <form :action="species_community_cs_form_url" method="post"
                                     name="new_conservation_status" enctype="multipart/form-data">
-                                    <ProposalConservationStatus ref="conservation_status"
-                                        :conservation_status_obj="conservation_status_obj" :referral="referral">
+                                    <ProposalConservationStatus v-if="conservation_status_obj && profile"
+                                        ref="conservation_status" :conservation_status_obj="conservation_status_obj"
+                                        :referral="referral" :is_internal="profile.is_internal">
                                     </ProposalConservationStatus>
                                     <input type="hidden" name="csrfmiddlewaretoken" :value="csrf_token" />
                                     <input type='hidden' name="conservation_status_id" :value="1" />
@@ -104,6 +105,7 @@ export default {
     name: 'ConservationStatusReferral',
     data: function () {
         return {
+            profile: null,
             savingConservationStatus: false,
             referral: null,
         }
@@ -112,11 +114,6 @@ export default {
         datatable,
         Submission,
         ProposalConservationStatus,
-    },
-    props: {
-        referralId: {
-            type: Number,
-        },
     },
     computed: {
         conservation_status_obj: function () {
@@ -236,8 +233,18 @@ export default {
                     console.log(err);
                 });
         },
+        fetchProfile() {
+            this.$http.get(api_endpoints.profile)
+                .then(response => {
+                    this.profile = response.data
+                })
+                .catch(error => {
+                    console.log(error)
+                })
+        },
     },
     created: function () {
+        this.fetchProfile();
         if (!this.referral) {
             this.fetchReferral();
         }

--- a/boranga/frontend/boranga/src/components/internal/occurrence/occurrence_report.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/occurrence_report.vue
@@ -237,7 +237,7 @@
                         <ProposalOccurrenceReport v-if="occurrence_report" :occurrence_report_obj="occurrence_report"
                             id="OccurrenceReportStart" :canEditStatus="false" :is_external="false" :is_internal="true"
                             ref="occurrence_report" @refreshFromResponse="refreshFromResponse"
-                            @refreshOccurrenceReport="refreshOccurrenceReport()">
+                            @refreshOccurrenceReport="refreshOccurrenceReport()" @saveOccurrenceReport="save_before_submit()">
                         </ProposalOccurrenceReport>
 
                         <input type="hidden" name="csrfmiddlewaretoken" :value="csrf_token" />
@@ -697,7 +697,6 @@ export default {
             });
         },
         save_before_submit: async function (e) {
-            //console.log('save before submit');
             let vm = this;
             vm.saveError = false;
 

--- a/boranga/frontend/boranga/src/components/internal/occurrence/referral.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/referral.vue
@@ -64,11 +64,11 @@
                             <div class="row">
                                 <form :action="species_community_ocr_form_url" method="post"
                                     name="new_occurrence_report" enctype="multipart/form-data">
-                                    <ProposalOccurrenceReport v-if="occurrence_report_obj"
+                                    <ProposalOccurrenceReport v-if="occurrence_report_obj && profile"
                                         :occurrence_report_obj="occurrence_report_obj" id="OccurrenceReportStart"
                                         :canEditStatus="canEditStatus" ref="occurrence_report" :referral="referral"
                                         @refreshOccurrenceReport="refreshOccurrenceReport()" :show_observer_contact_information="false"
-                                        @refreshFromResponse="refreshFromResponse">
+                                        @refreshFromResponse="refreshFromResponse" :is_internal="is_internal">
                                     </ProposalOccurrenceReport>
                                     <input type="hidden" name="csrfmiddlewaretoken" :value="csrf_token" />
                                     <input type='hidden' name="occurrence_report_id" :value="1" />
@@ -107,6 +107,7 @@ export default {
     name: 'OccurrenceReportReferral',
     data: function () {
         return {
+            profile: null,
             savingOccurrenceReport: false,
             referral: null,
         }
@@ -115,11 +116,6 @@ export default {
         datatable,
         Submission,
         ProposalOccurrenceReport,
-    },
-    props: {
-        referralId: {
-            type: Number,
-        },
     },
     computed: {
         occurrence_report_obj: function () {
@@ -245,8 +241,18 @@ export default {
                     console.log(err);
                 });
         },
+        fetchProfile() {
+            this.$http.get(api_endpoints.profile)
+                .then(response => {
+                    this.profile = response.data
+                })
+                .catch(error => {
+                    console.log(error)
+                })
+        },
     },
     created: function () {
+        this.fetchProfile();
         if (!this.referral) {
             this.fetchReferral();
         }

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
@@ -1,9 +1,7 @@
 <template lang="html">
     <div v-if="species_community" class="container" id="internalSpeciesCommunity">
         <div class="row" style="padding-bottom: 50px;">
-            <h3>{{ display_group_type }} {{ display_number }} - {{ display_name }} <span
-                    v-if="this.species_community.taxonomy_details.community_migrated_id" class="h5 text-muted"> (Migrated
-                    from: {{ this.species_community.taxonomy_details.community_migrated_id }})</span></h3>
+            <h3>{{ display_group_type }} {{ display_number }} - {{ display_name }}</h3>
             <div v-if="!comparing" class="col-md-3">
                 <!-- TODO -->
                 <template>
@@ -314,7 +312,7 @@ export default {
         },
         display_name: function () {
             return (this.species_community.group_type === "community") ?
-                (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.community_name : '' :
+                (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.community_migrated_id : '' :
                 (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.scientific_name + " (" + this.species_community.taxonomy_details.taxon_name_id + ")" : '';
         },
         class_ncols: function () {

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
@@ -1,7 +1,9 @@
 <template lang="html">
     <div v-if="species_community" class="container" id="internalSpeciesCommunity">
         <div class="row" style="padding-bottom: 50px;">
-            <h3>{{ display_group_type }} {{ display_number }} - {{ display_name }}</h3>
+            <h3>{{ display_group_type }} {{ display_number }} - {{ display_name }} <span
+                    v-if="this.species_community.taxonomy_details.community_migrated_id" class="h5 text-muted"> (Migrated
+                    from: {{ this.species_community.taxonomy_details.community_migrated_id }})</span></h3>
             <div v-if="!comparing" class="col-md-3">
                 <!-- TODO -->
                 <template>
@@ -312,7 +314,7 @@ export default {
         },
         display_name: function () {
             return (this.species_community.group_type === "community") ?
-                (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.community_migrated_id : '' :
+                (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.community_name : '' :
                 (this.species_community.taxonomy_details != null) ? this.species_community.taxonomy_details.scientific_name + " (" + this.species_community.taxonomy_details.taxon_name_id + ")" : '';
         },
         class_ncols: function () {


### PR DESCRIPTION
- Remove mandatory field indicators when SC form is readonly (e.g. when being viewed by public)
- Query optimisation for some SC viewsets
- Fix tab loading issue on OCR when tabs are clicked too quickly
- Resove some silent js errors on OCR / OCC when refs were being referred to before they were mounted
- Make sure submitter information form is always disabled for referees
- Remove documents datatable from main OCR profile tab for referees as they have access to the documents tab (unlike external contributors)
- Replace is_staff property on UserSerializer with is_internal as is staff was not being used and is_internal was needed
- Add auto save to OCR profile form
- Don't recreate the map component in save_before_submit as was causing map loading error (will monitor this change for regressions)