### PR TITLE
Vue errors + subprocess removal

### DIFF
--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -2,7 +2,6 @@ import json
 import logging
 import mimetypes
 import os
-import subprocess
 from datetime import datetime
 from io import BytesIO
 
@@ -1666,11 +1665,11 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             new_doc_instance.species = new_rename_instance
             new_doc_instance.id = None
             new_doc_instance.document_number = ""
-            new_doc_instance._file.name = (
-                "boranga/species/{}/species_documents/{}".format(
-                    new_rename_instance.id, new_doc_instance.name
-                )
-            )
+            #new_doc_instance._file.name = (
+            #    "boranga/species/{}/species_documents/{}".format(
+            #        new_rename_instance.id, new_doc_instance.name
+            #    )
+            #)
             new_doc_instance.can_delete = True
             new_doc_instance.save(version_user=request.user)
             new_doc_instance.species.log_user_action(
@@ -1687,37 +1686,6 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                 ),
                 request,
             )
-
-            check_path = os.path.exists(
-                "private-media/boranga/species/{}/species_documents/".format(
-                    new_rename_instance.id
-                )
-            )
-            if check_path is True:
-                # copy documents on file system
-                subprocess.call(
-                    "cp -p private-media/boranga/species/{}/species_documents/{}  \
-                        private-media/boranga/species/{}/species_documents/".format(
-                        instance.id, new_doc_instance.name, new_rename_instance.id
-                    ),
-                    shell=True,
-                )
-            else:
-                # create new directory
-                os.makedirs(
-                    "private-media/boranga/species/{}/species_documents/".format(
-                        new_rename_instance.id
-                    ),
-                    mode=0o777,
-                )
-                # then copy documents on file system
-                subprocess.call(
-                    "cp -p private-media/boranga/species/{}/species_documents/{}  \
-                        private-media/boranga/species/{}/species_documents/".format(
-                        instance.id, new_doc_instance.name, new_rename_instance.id
-                    ),
-                    shell=True,
-                )
 
         for new_threat in instance_threats:
             new_threat_instance = new_threat

--- a/boranga/components/species_and_communities/models.py
+++ b/boranga/components/species_and_communities/models.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import subprocess
 
 import reversion
 import shapely.geometry as shp
@@ -811,9 +810,8 @@ class Species(RevisionedMixin):
                 new_species_doc.species = self
                 new_species_doc.id = None
                 new_species_doc.document_number = ""
-                new_species_doc._file.name = f"boranga/species/{self.id}/species_documents/{new_species_doc.name}"
                 new_species_doc.can_delete = True
-                new_species_doc.save()
+                new_species_doc.save(version_user=request.user)
                 new_species_doc.species.log_user_action(
                     SpeciesUserAction.ACTION_ADD_DOCUMENT.format(
                         new_species_doc.document_number,
@@ -828,31 +826,6 @@ class Species(RevisionedMixin):
                     ),
                     request,
                 )
-
-                check_path = os.path.exists(
-                    f"private-media/boranga/species/{self.id}/species_documents/"
-                )
-                if check_path:
-                    # copy documents on file system
-                    subprocess.call(
-                        f"cp -p private-media/boranga/species/{original_species.id}"
-                        f"/species_documents/{new_species_doc.name} "
-                        f"private-media/boranga/species/{self.id}/species_documents/",
-                        shell=True,
-                    )
-                else:
-                    # create new directory
-                    os.makedirs(
-                        f"private-media/boranga/species/{self.id}/species_documents/",
-                        mode=0o777,
-                    )
-                    # then copy documents on file system
-                    subprocess.call(
-                        f"cp -p private-media/boranga/species/{original_species.id}"
-                        f"/species_documents/{new_species_doc.name} "
-                        f"private-media/boranga/species/{self.id}/species_documents/",
-                        shell=True,
-                    )
 
     def clone_threats(self, request):
         with transaction.atomic():
@@ -2610,7 +2583,10 @@ class SystemEmailGroup(models.Model):
 
     @classmethod
     def emails_by_group_and_area(cls, group_type, area=None):
-        group = cls.objects.get(group_type=group_type, area=area)
+        try:
+            group = cls.objects.get(group_type=group_type, area=area)
+        except:
+            return []
         return group.email_address_list
 
 

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_combine/species_combine_documents.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_combine/species_combine_documents.vue
@@ -266,9 +266,9 @@ export default {
         mounted: function(){
             let vm = this;
             this.$nextTick(() => {
-                if(vm.species_original.document_selection!=null){
+                if(vm.species_original.document_selection !== undefined && vm.species_original.document_selection !== null){
 
-                    if(vm.species_original.document_selection==="selectAll"){
+                    if(vm.species_original.document_selection === "selectAll"){
                         document.getElementById('doc_select_all'+vm.species_original.id).checked=true;
                     }
                     else{

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_combine/species_combine_threats.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_combine/species_combine_threats.vue
@@ -278,7 +278,7 @@ export default {
                         vm.species_community.threats.splice(index,1);
                     }
                 });
-                vm.$refs.documents_datatable.vmDataTable.on('childRow.dt', function (e, settings) {
+                vm.$refs.threats_datatable.vmDataTable.on('childRow.dt', function (e, settings) {
                     helpers.enablePopovers();
                 });
             },

--- a/boranga/frontend/boranga/src/components/internal/meetings/agenda_datatable.vue
+++ b/boranga/frontend/boranga/src/components/internal/meetings/agenda_datatable.vue
@@ -169,7 +169,6 @@ export default {
     data: function () {
         let vm = this;
         return {
-            species_community_original: null,
             isModalOpen: false,
             new_species_list: [],
             user_preference: 'flora',    // TODO : set it to default user preference but for now is hardcoded value
@@ -194,10 +193,6 @@ export default {
         title: function () {
             //return this.processing_status == 'With Approver' ? 'Approve Conservation Status' : 'Propose to approve Conservation Status';
             return 'Agenda (Add Conservation Status)';
-        },
-        species_split_form_url: function () {
-            var vm = this;
-            return `/api/species/${vm.species_community_original.id}/species_split_save.json`;
         },
         /*---------properties to load group related vue components-------------*/
         isFlora: function () {

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_combine.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_combine.vue
@@ -44,6 +44,7 @@
                                         :key="'div' + species.id" class="tab-pane fade" :id="'species-body-' + index"
                                         role="tabpanel" :aria-labelledby="'pills-species' + index + '-tab'">
                                         <SpeciesCommunitiesComponent :ref="'species_communities_species' + index"
+                                            :species_community_original="species"
                                             :species_community.sync="species" :id="'species-' + index"
                                             :is_internal="true" :is_readonly="true">
                                         </SpeciesCommunitiesComponent>

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_rename.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_rename.vue
@@ -8,6 +8,7 @@
                         <div>
                             <div class="col-md-12">
                                 <SpeciesCommunitiesComponent v-if="new_rename_species != null" ref="rename_species"
+                                    :species_community_original="new_rename_species"
                                     :species_community.sync="new_rename_species" id="rename_species" :is_internal="true"
                                     :is_readonly="true" :rename_species="true"> // rename=true used to make only taxon
                                     select editable on form

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_split.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_split.vue
@@ -36,6 +36,7 @@
                                         aria-labelledby="pills-original-tab">
                                         <SpeciesCommunitiesComponent v-if="species_community_original != null"
                                             ref="species_communities_original"
+                                            :species_community_original="species_community_original"
                                             :species_community.sync="species_community_original" id="species_original"
                                             :is_internal="true" :is_readonly="true">
                                             <!-- this prop is only send from split species form to make the original species readonly -->


### PR DESCRIPTION
Fixed a number vue errors from missing props via the S&C split, combine, and rename functions.

Removed subprocess calls to copy documents to new dir after split, combine, and rename functions.

Subprocess calls were removed as they did not work reliably (some instances where directories would not be created to certain files would not be copied). 

As of this change copied S&C document records now point to the original file in its original upload location, under the sub-dir id of the original record. This is the same for OCC documents.

IF S&C or OCC documents are ever to become available to users on a record-by-record basis, then the files will either require copying/moving or the parent id must be otherwise obtainable to auth the user's access. As of now, neither use case appears to be required. If copying/moving is to be done, should be ideally conducted via python over subprocesses if possible.