### PR TITLE
Workflow and Display adjustments

### DIFF
--- a/boranga/components/occurrence/permissions.py
+++ b/boranga/components/occurrence/permissions.py
@@ -219,7 +219,15 @@ class ExternalOccurrenceReportPermission(BasePermission):
         if request.user.is_superuser:
             return True
 
-        return is_contributor(request)
+        return (
+                is_contributor(request) 
+                or is_readonly_user(request)
+                or is_conservation_status_assessor(request)
+                or is_conservation_status_approver(request)
+                or is_species_communities_approver(request)
+                or is_occurrence_assessor(request)
+                or is_occurrence_approver(request)
+            )
 
     def has_object_permission(self, request, view, obj):
         if (
@@ -232,8 +240,15 @@ class ExternalOccurrenceReportPermission(BasePermission):
             obj.can_user_edit
             or (hasattr(view, "action") and view.action == "process_shapefile_document")
         ):
-            return is_contributor(request)
-
+            return (
+                is_contributor(request) 
+                or is_readonly_user(request)
+                or is_conservation_status_assessor(request)
+                or is_conservation_status_approver(request)
+                or is_species_communities_approver(request)
+                or is_occurrence_assessor(request)
+                or is_occurrence_approver(request)
+            )
         return False
 
 
@@ -366,7 +381,15 @@ class ExternalOccurrenceReportObjectPermission(BasePermission):
         if request.user.is_superuser:
             return True
 
-        return is_contributor(request)
+        return (
+                is_contributor(request) 
+                or is_readonly_user(request)
+                or is_conservation_status_assessor(request)
+                or is_conservation_status_approver(request)
+                or is_species_communities_approver(request)
+                or is_occurrence_assessor(request)
+                or is_occurrence_approver(request)
+            )
 
     def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS:
@@ -379,7 +402,15 @@ class ExternalOccurrenceReportObjectPermission(BasePermission):
             and occurrence_report.submitter == request.user.id
             and occurrence_report.can_user_edit
         ):
-            return is_contributor(request)
+            return (
+                is_contributor(request) 
+                or is_readonly_user(request)
+                or is_conservation_status_assessor(request)
+                or is_conservation_status_approver(request)
+                or is_species_communities_approver(request)
+                or is_occurrence_assessor(request)
+                or is_occurrence_approver(request)
+            )
 
         return False
 

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -1295,11 +1295,16 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
 
         return Response(data)
 
+
     @detail_route(methods=["post"], detail=True)
     @renderer_classes((JSONRenderer,))
     @transaction.atomic
     def species_save(self, request, *args, **kwargs):
         instance = self.get_object()
+
+        if not instance.can_user_save(request):
+            raise serializers.ValidationError("Cannot save species record in current state")
+
         request_data = request.data
         if request_data["submitter"]:
             request.data["submitter"] = "{}".format(request_data["submitter"].get("id"))
@@ -1467,6 +1472,8 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     def submit(self, request, *args, **kwargs):
         instance = self.get_object()
         # instance.submit(request,self)
+        if not instance.can_user_submit(request):
+            raise serializers.ValidationError("Cannot submit a species record with current status")
         species_form_submit(instance, request)
         instance.save(version_user=request.user)
         serializer = self.get_serializer(instance)
@@ -1986,6 +1993,10 @@ class CommunityViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     @transaction.atomic
     def community_save(self, request, *args, **kwargs):
         instance = self.get_object()
+
+        if not instance.can_user_save(request):
+            raise serializers.ValidationError("Cannot save community record in current state")
+        
         request_data = request.data
         if request_data["submitter"]:
             request.data["submitter"] = "{}".format(request_data["submitter"].get("id"))
@@ -2097,6 +2108,8 @@ class CommunityViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     def submit(self, request, *args, **kwargs):
         instance = self.get_object()
         # instance.submit(request,self)
+        if not instance.can_user_submit(request):
+            raise serializers.ValidationError("Cannot submit community record in current state")
         community_form_submit(instance, request)
         instance.save(version_user=request.user)
         serializer = self.get_serializer(instance)

--- a/boranga/components/species_and_communities/models.py
+++ b/boranga/components/species_and_communities/models.py
@@ -649,6 +649,30 @@ class Species(RevisionedMixin):
             return False
 
         return is_species_communities_approver(request) or request.user.is_superuser
+    
+    def can_user_save(self, request):
+        user_closed_state = [
+            Species.PROCESSING_STATUS_HISTORICAL,
+            Species.PROCESSING_STATUS_DISCARDED,
+        ]
+
+        if self.processing_status in user_closed_state:
+           return False
+
+        return is_species_communities_approver(request) or request.user.is_superuser
+    
+    def can_user_submit(self, request):
+        user_submissable_state = [
+            Species.PROCESSING_STATUS_DRAFT
+        ]
+
+        if not self.can_user_save(request):
+            return False
+
+        if not self.processing_status in user_submissable_state:
+            return False
+
+        return is_species_communities_approver(request) or request.user.is_superuser
 
     def has_user_edit_mode(self, request):
         officer_view_state = ["draft", "historical"]
@@ -1291,6 +1315,30 @@ class Community(RevisionedMixin):
             return False
         else:
             return True
+        
+    def can_user_save(self, request):
+        user_closed_state = [
+            Species.PROCESSING_STATUS_HISTORICAL,
+            Species.PROCESSING_STATUS_DISCARDED,
+        ]
+
+        if self.processing_status in user_closed_state:
+           return False
+
+        return is_species_communities_approver(request) or request.user.is_superuser
+    
+    def can_user_submit(self, request):
+        user_submissable_state = [
+            Species.PROCESSING_STATUS_DRAFT
+        ]
+
+        if not self.can_user_save(request):
+            return False
+
+        if not self.processing_status in user_submissable_state:
+            return False
+
+        return is_species_communities_approver(request) or request.user.is_superuser
 
     @property
     def is_deletable(self):

--- a/boranga/components/species_and_communities/serializers.py
+++ b/boranga/components/species_and_communities/serializers.py
@@ -870,7 +870,7 @@ class InternalSpeciesSerializer(BaseSpeciesSerializer):
         request = self.context["request"]
         if request.user.is_superuser:
             return False
-        return not (obj.can_user_edit and is_species_communities_approver(request))
+        return not ((obj.can_user_edit and is_species_communities_approver(request)) or obj.has_user_edit_mode)
 
     def get_can_add_log(self, obj):
         request = self.context["request"]
@@ -1301,8 +1301,7 @@ class InternalCommunitySerializer(BaseCommunitySerializer):
         request = self.context["request"]
         if request.user.is_superuser:
             return False
-
-        return not (obj.can_user_edit and is_species_communities_approver(request))
+        return not ((obj.can_user_edit and is_species_communities_approver(request)) or obj.has_user_edit_mode)
 
     def get_can_add_log(self, obj):
         request = self.context["request"]

--- a/boranga/components/species_and_communities/serializers.py
+++ b/boranga/components/species_and_communities/serializers.py
@@ -870,7 +870,7 @@ class InternalSpeciesSerializer(BaseSpeciesSerializer):
         request = self.context["request"]
         if request.user.is_superuser:
             return False
-        return not ((obj.can_user_edit and is_species_communities_approver(request)) or obj.has_user_edit_mode)
+        return not ((obj.can_user_edit or obj.has_user_edit_mode) and is_species_communities_approver(request))
 
     def get_can_add_log(self, obj):
         request = self.context["request"]
@@ -1301,7 +1301,7 @@ class InternalCommunitySerializer(BaseCommunitySerializer):
         request = self.context["request"]
         if request.user.is_superuser:
             return False
-        return not ((obj.can_user_edit and is_species_communities_approver(request)) or obj.has_user_edit_mode)
+        return not ((obj.can_user_edit or obj.has_user_edit_mode) and is_species_communities_approver(request))
 
     def get_can_add_log(self, obj):
         request = self.context["request"]

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
@@ -27,14 +27,14 @@
                                             <div class="align-self-center text-muted">No Image Uploaded</div>
                                         </div>
                                     </div>
-                                    <div v-if="hasUserEditMode" class="row border-top pt-3 mb-2">
+                                    <div v-if="hasUserEditMode && species_community.processing_status != 'Discarded'" class="row border-top pt-3 mb-2">
                                         <div class="col">
                                             <div class="d-flex justify-content-center">
                                                 <div class="text-muted">Image Actions</div>
                                             </div>
                                         </div>
                                     </div>
-                                    <div v-if="hasUserEditMode" class="row">
+                                    <div v-if="hasUserEditMode && species_community.processing_status != 'Discarded'" class="row">
                                         <div class="col">
                                             <div class="d-flex align-items-center flex-column">
                                                 <label v-if="!speciesCommunitiesImage" for="image-upload" role="button"
@@ -105,7 +105,7 @@
                                                 <strong>Action</strong><br />
                                             </div>
                                         </div>
-                                        <div class="row" v-if="!isCommunity">
+                                        <div class="row" v-if="!isCommunity && isActive">
                                             <div class="col-sm-12">
                                                 <button style="width:80%;" class="btn btn-primary top-buffer-s"
                                                     @click.prevent="splitSpecies()">Split</button><br />
@@ -179,7 +179,7 @@
                                         :species_community="species_community"
                                         :species_community_original="species_community_original"
                                         id="speciesCommunityStart" :is_internal="true"
-                                        :is_readonly="species_community.readonly">
+                                        :is_readonly="species_community.readonly || species_community.processing_status == 'Discarded'">
                                     </ProposalSpeciesCommunities>
                                     <input type="hidden" name="csrfmiddlewaretoken" :value="csrf_token" />
                                     <input type='hidden' name="species_community_id" :value="1" />
@@ -191,7 +191,7 @@
                                                     @click.prevent="returnToDashboard">
                                                         Return to Dashboard</button>
                                                 </div>
-                                                <div v-if="species_community.can_user_edit" class="col-md-6 text-end">
+                                                <div v-if="species_community.can_user_edit && species_community.processing_status != 'Discarded'" class="col-md-6 text-end">
                                                     <button v-if="savingSpeciesCommunity"
                                                         class="btn btn-primary me-2 pull-right" style="margin-top:5px;"
                                                         disabled>Save and Continue&nbsp;
@@ -218,7 +218,7 @@
                                                         style="margin-top:5px;" @click.prevent="submit()"
                                                         :disabled="saveExitSpeciesCommunity || savingSpeciesCommunity">Submit</button>
                                                 </div>
-                                                <div v-else-if="hasUserEditMode" class="col-md-6 text-end">
+                                                <div v-else-if="hasUserEditMode && species_community.processing_status != 'Discarded'" class="col-md-6 text-end">
                                                     <button v-if="savingSpeciesCommunity"
                                                         class="btn btn-primary pull-right" style="margin-top:5px;"
                                                         disabled>Save Changes&nbsp;
@@ -359,13 +359,7 @@ export default {
             return true
         },
         hasUserEditMode: function () {
-            // Need to check for approved status as to show 'Save changes' button only when edit and not while view
-            if (this.$route.query.action == 'edit') {
-                return this.species_community && this.species_community.user_edit_mode ? true : false;
-            }
-            else {
-                return false;
-            }
+            return this.species_community && this.species_community.user_edit_mode ? true : false;
         },
         canReopen: function () {
             return (this.species_community && this.species_community.can_user_reopen) ? true : false;


### PR DESCRIPTION
- Adjusted save buttons, history table, and threat table to be available when S&C record active/draft and not when discard/historical (with reinstate/reopen options available)
- Added server-side status checks for uploading documents, threats, and images to S&C records (discarded/historical must be resinstated/reopened first)
- External permissions for OCR and CS include internal groups now (Read and Create already available, but not update) 
- Fixed readonly for S&C so that it will return true for unauthorised users

Some minor client-side issues exist for CS, deferred for later maintenance.

Creating new S&C records via split/rename/combine remains unregulated via processing status on the server-side - should be addressed once aforementioned processes are reworked.