### PR TITLE
Build Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN chmod 755 /startup.sh && \
     mkdir /tmp/azcopy/ && \
     wget https://aka.ms/downloadazcopy-v10-linux -O /tmp/azcopy/azcopy.tar.gz && \
     cd /tmp/azcopy/ ; tar -xzvf azcopy.tar.gz && \
-    cp /tmp/azcopy/azcopy_linux_amd64_10.25.1/azcopy /bin/azcopy && \
+    cp /tmp/azcopy/azcopy_linux_amd64_10.*/azcopy /bin/azcopy && \
     chmod 755 /bin/azcopy && \
     rm -rf /tmp/azcopy/
 


### PR DESCRIPTION
- Update azcopy installation to work even if the minor and or patch version has increased