### PR TITLE
Map transform coordinates from map to user input

### DIFF
--- a/boranga/components/occurrence/api.py
+++ b/boranga/components/occurrence/api.py
@@ -5400,10 +5400,13 @@ class OccurrenceViewSet(
             "GET",
         ],
         detail=False,
-        url_path="available-occurrence-reports-crs",
+        url_path="available-crs-for-occurrence",
     )
-    def available_occurrence_reports_crs(self, request, *args, **kwargs):
-        """used for Occurrence Report external form"""
+    def available_crs_for_occurrence(self, request, *args, **kwargs):
+        """Returns the available CRS for the occurrence, occurrence report, and
+        site geometries associated with this occurrence
+        """
+
         qs = self.get_queryset()
         crs = []
 

--- a/boranga/frontend/boranga/src/components/common/component_map.vue
+++ b/boranga/frontend/boranga/src/components/common/component_map.vue
@@ -1622,6 +1622,7 @@ import { FullScreen as FullScreenControl } from 'ol/control';
 import { LineString, Point, MultiPoint, Polygon, MultiPolygon } from 'ol/geom';
 import { fromExtent } from 'ol/geom/Polygon';
 import { getArea } from 'ol/sphere.js';
+import { transform as transformCoordinates } from 'ol/proj';
 import GeoJSON from 'ol/format/GeoJSON';
 import Overlay from 'ol/Overlay.js';
 import DragAndDrop from 'ol/interaction/DragAndDrop.js';
@@ -3895,7 +3896,18 @@ export default {
             modify.addEventListener('modifyend', function (evt) {
                 console.log('Modify end', evt.features);
                 const feature = evt.features[0];
-                const coordinates = feature.getGeometry().getCoordinates();
+                const original_srid =
+                    feature.getProperties().original_geometry.properties.srid;
+                let coordinates = feature.getGeometry().getCoordinates();
+                if (original_srid != vm.mapSrid) {
+                    // Transform the coordinates from the map crs to the user input crs
+                    coordinates = transformCoordinates(
+                        coordinates,
+                        `EPSG:${vm.mapSrid}`,
+                        `EPSG:${original_srid}`
+                    );
+                }
+
                 vm.userCoordinates(feature, coordinates);
                 vm.emitValidateFeature(feature);
             });
@@ -3914,7 +3926,18 @@ export default {
                 // eslint-disable-next-line no-unused-vars
                 evt.features.forEach((feature) => {
                     vm.emitValidateFeature(feature);
-                    const coordinates = feature.getGeometry().getCoordinates();
+                    const original_srid =
+                        feature.getProperties().original_geometry.properties
+                            .srid;
+                    let coordinates = feature.getGeometry().getCoordinates();
+                    if (original_srid != vm.mapSrid) {
+                        // Transform the coordinates from the map crs to the user input crs
+                        coordinates = transformCoordinates(
+                            coordinates,
+                            `EPSG:${vm.mapSrid}`,
+                            `EPSG:${original_srid}`
+                        );
+                    }
                     vm.userCoordinates(feature, coordinates);
                 });
             };

--- a/boranga/frontend/boranga/src/components/common/occurrence/occ_locations.vue
+++ b/boranga/frontend/boranga/src/components/common/occurrence/occ_locations.vue
@@ -521,7 +521,7 @@ export default {
         fetch(
             helpers.add_endpoint_join(
                 api_endpoints.occurrence,
-                `/available-occurrence-reports-crs/?id=${this.occurrence_obj.id}`
+                `/available-crs-for-occurrence/?id=${this.occurrence_obj.id}`
             )
         )
             .then((response) => {


### PR DESCRIPTION
- Moving point features on the map now correctly updates the user input coordinates in the geometry list if they are in a different crs than wgs-84
- Fixed api endpoint for available crs srid not returning all crs of all geometries, which resulted in some geometries being initialised in the geometry list with an empty crs select value if the crs srid was different from 4326