### PR TITLE
Rename and Split Species Tweaks

### DIFF
--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -2053,12 +2053,16 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                     SpeciesUserAction.ACTION_RENAME_SPECIES_FROM_EXISTING_HISTORICAL
                 )
 
+            rename_instance = rename_deep_copy(
+                request, instance, existing_species=rename_instance
+            )
             rename_instance.processing_status = Species.PROCESSING_STATUS_ACTIVE
             rename_instance.save(version_user=request.user)
         else:
-            rename_instance = rename_deep_copy(instance, request)
+            rename_instance = rename_deep_copy(request, instance)
             rename_instance.taxonomy_id = request.data["taxonomy_id"]
-            species_form_submit(rename_instance, request)
+            rename_instance.processing_status = Species.PROCESSING_STATUS_ACTIVE
+            species_form_submit(rename_instance, request, rename=True)
 
         rename_instance.parent_species.add(instance)
 

--- a/boranga/components/species_and_communities/email.py
+++ b/boranga/components/species_and_communities/email.py
@@ -286,9 +286,6 @@ def send_species_combine_email_notification(
 def send_species_rename_email_notification(request, species_proposal, new_species):
     email = RenameSpeciesSendNotificationEmail()
 
-    url = request.build_absolute_uri(
-        reverse("internal-conservation-status-dashboard", kwargs={})
-    )
     species_url = request.build_absolute_uri(
         reverse(
             "internal-species-detail",
@@ -310,58 +307,12 @@ def send_species_rename_email_notification(request, species_proposal, new_specie
 
     all_ccs = notification_emails
 
-    conservation_status_url = []
-    conservation_status_list = species_proposal.conservation_status.filter(
-        processing_status=ConservationStatus.PROCESSING_STATUS_APPROVED
-    )
-    if conservation_status_list:
-        conservation_status_url = request.build_absolute_uri(
-            reverse(
-                "internal-conservation-status-detail",
-                kwargs={"cs_proposal_pk": conservation_status_list[0].id},
-            )
-        )
-        cs_notification_emails = SystemEmailGroup.emails_by_group_and_area(
-            group_type=species_proposal.group_type,
-            area=SystemEmailGroup.AREA_CONSERVATION_STATUS,
-        )
-        all_ccs.extend(cs_notification_emails)
-
-    occurrences_url = []
-    occurrences = species_proposal.occurrences.filter(
-        processing_status=Occurrence.PROCESSING_STATUS_ACTIVE
-    )
-    if occurrences:
-        for occ in occurrences:
-            occurrences_url.append(
-                {
-                    "occurrence_url": request.build_absolute_uri(
-                        reverse(
-                            "internal-occurrence-detail",
-                            kwargs={"occurrence_pk": occ.id},
-                        )
-                    ),
-                    "occurrence_number": occ.occurrence_number,
-                }
-            )
-
-        occ_notification_emails = SystemEmailGroup.emails_by_group_and_area(
-            group_type=species_proposal.group_type,
-            area=SystemEmailGroup.AREA_OCCURRENCE,
-        )
-        all_ccs.extend(occ_notification_emails)
-
     context = {
         "species_proposal": species_proposal,
-        "url": url,
         "species_url": species_url,
         "new_species_url": new_species_url,
         "new_species": new_species,
-        "conservation_status_url": conservation_status_url,
-        "occurrences_url": occurrences_url,
     }
-
-    all_ccs = list(set(all_ccs))
 
     submitter_email = EmailUser.objects.get(id=species_proposal.submitter).email
 

--- a/boranga/components/species_and_communities/templates/boranga/emails/send_rename_notification.html
+++ b/boranga/components/species_and_communities/templates/boranga/emails/send_rename_notification.html
@@ -1,22 +1,21 @@
 {%  extends 'boranga/emails/base_email.html' %}
 
 {%  block content %}
-    <p>Species {{ species_proposal.species_number }} has been renamed. You can review the historical and new Species Profiles at:</p>
+    <p>Species</p>
     <ul>
-        <li>Historical: <a href="{{species_url}}">{{ species_proposal.species_number }} - {{ species_proposal.taxonomy.scientific_name }}</a></li>
-        <li>New: <a href="{{new_species_url}}">{{ new_species.species_number }} - {{ new_species.taxonomy.scientific_name }}</a></li>
+        <li>Original: <a href="{{species_url}}">{{ species_proposal.species_number }} - {{ species_proposal.taxonomy.scientific_name }}</a></li>
+    </ul>
+    <p>has been renamed to:
+    <ul>
+        <li>Resulting: <a href="{{new_species_url}}">{{ new_species.species_number }} - {{ new_species.taxonomy.scientific_name }}</a></li>
     </ul>
     <p>
-        {% if conservation_status_url %}
-            Please action the related Conservation Status <a href="{{conservation_status_url}}">here</a>
-        {% endif %}
+        The original species has been made historical.
     </p>
     <p>
-        {% if occurrences_url %}
-            Please action any related Occurrences:
-            {% for occ in occurrences_url %}
-                <li><a href="{{occ.occurrence_url}}">{{ occ.occurrence_number }}</a></li>
-            {% endfor %}
-        {% endif %}
+        Any approved conservation status for the original species has been closed.
+    </p>
+    <p>
+        Any and all occurrences have been moved from the original species to the resulting species.
     </p>
 {%  endblock %}

--- a/boranga/components/species_and_communities/templates/boranga/emails/send_rename_notification.txt
+++ b/boranga/components/species_and_communities/templates/boranga/emails/send_rename_notification.txt
@@ -1,16 +1,21 @@
 {%  extends 'boranga/emails/base_email.txt' %}
 
 {%  block content %}
-        Species {{ species_proposal.species_number }} has been renamed. You can review the historical and new Species Profiles at:
-        Historical: {{species_url}} {{ species_proposal.species_number }} - {{ species_proposal.taxonomy.scientific_name }}
-        New: {{new_species_url}} {{ new_species.species_number }} - {{ new_species.taxonomy.scientific_name }}
-        {% if conservation_status_url %}
-            Please action the related Conservation Status here {{conservation_status_url}}
-        {% endif %}
-        {% if occurrences_url %}
-            To action related Occurrences:
-            {% for occ in occurrences_url %}
-                {{ occ.occurrence_number }}
-            {% endfor %}
-        {% endif %}
+    Species
+
+    Original: {{ species_proposal.species_number }} - {{ species_proposal.taxonomy.scientific_name }}
+
+    ({{species_url}})
+
+    has been renamed to:
+
+    Resulting: {{ new_species.species_number }} - {{ new_species.taxonomy.scientific_name }}
+
+    ({{new_species_url}})
+
+    The original species has been made historical.
+
+    Any approved conservation status for the original species has been closed.
+
+    Any and all occurrences have been moved from the original species to the resulting species.
 {%  endblock %}

--- a/boranga/components/species_and_communities/utils.py
+++ b/boranga/components/species_and_communities/utils.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 
 @transaction.atomic
-def species_form_submit(species_instance, request, split=False):
-    if not split:
+def species_form_submit(species_instance, request, split=False, rename=False):
+    if not split and not rename:
         if not species_instance.can_user_edit:
             raise ValidationError("You can't submit this species at this moment")
 

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_split.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_split.vue
@@ -196,174 +196,185 @@
                                                         : ''
                                                 "
                                             >
-                                                <table
-                                                    class="table table-sm"
-                                                    style="
-                                                        table-layout: fixed;
-                                                        width: 100%;
-                                                    "
+                                                <div
+                                                    class="overflow-auto"
+                                                    style="max-height: 60vh"
                                                 >
-                                                    <colgroup>
-                                                        <col
-                                                            style="width: 25%"
-                                                        />
-                                                        <col
-                                                            v-for="i in split_species_taxonomy_ids.length"
-                                                            :key="i"
-                                                            :style="{
-                                                                width:
-                                                                    abbrColPercent +
-                                                                    '%',
-                                                            }"
-                                                        />
-                                                    </colgroup>
-                                                    <thead>
-                                                        <tr>
-                                                            <th>
-                                                                Occs for
-                                                                {{
-                                                                    species_community_original
-                                                                        .taxonomy_details
-                                                                        .scientific_name
-                                                                }}
-                                                            </th>
-                                                            <th
-                                                                v-for="name in uniqueScientificNames"
-                                                                :key="
-                                                                    name.scientificName
+                                                    <table
+                                                        class="table table-sm"
+                                                        style="
+                                                            table-layout: fixed;
+                                                            width: 100%;
+                                                        "
+                                                    >
+                                                        <colgroup>
+                                                            <col
+                                                                style="
+                                                                    width: 25%;
                                                                 "
-                                                                :title="
-                                                                    name.full
-                                                                "
-                                                                class="text-center"
-                                                                :style="{
-                                                                    width:
-                                                                        abbrColPercent +
-                                                                        '%',
-                                                                }"
-                                                            >
-                                                                {{ name.abbr }}
-                                                            </th>
-                                                        </tr>
-                                                    </thead>
-                                                    <tbody>
-                                                        <tr
-                                                            class="border-bottom border-dark"
-                                                        >
-                                                            <td
-                                                                class="text-muted"
-                                                            >
-                                                                Select All
-                                                            </td>
-                                                            <td
-                                                                v-for="(
-                                                                    taxonomy_id,
-                                                                    i
-                                                                ) in split_species_taxonomy_ids"
+                                                            />
+                                                            <col
+                                                                v-for="i in split_species_taxonomy_ids.length"
                                                                 :key="i"
-                                                                class="text-center"
                                                                 :style="{
                                                                     width:
                                                                         abbrColPercent +
                                                                         '%',
                                                                 }"
-                                                            >
-                                                                <div
-                                                                    class="form-check form-check-inline"
+                                                            />
+                                                        </colgroup>
+                                                        <thead>
+                                                            <tr>
+                                                                <th>
+                                                                    Occs for
+                                                                    {{
+                                                                        species_community_original
+                                                                            .taxonomy_details
+                                                                            .scientific_name
+                                                                    }}
+                                                                </th>
+                                                                <th
+                                                                    v-for="name in uniqueScientificNames"
+                                                                    :key="
+                                                                        name.scientificName
+                                                                    "
+                                                                    :title="
+                                                                        name.full
+                                                                    "
+                                                                    class="text-center"
+                                                                    :style="{
+                                                                        width:
+                                                                            abbrColPercent +
+                                                                            '%',
+                                                                    }"
                                                                 >
-                                                                    <input
-                                                                        type="checkbox"
-                                                                        class="form-check-input mt-2"
-                                                                        @change="
-                                                                            toggleSelectAll(
-                                                                                $event,
-                                                                                taxonomy_id
-                                                                            )
-                                                                        "
-                                                                        :checked="
-                                                                            selectAllCheckedState[
+                                                                    {{
+                                                                        name.abbr
+                                                                    }}
+                                                                </th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            <tr
+                                                                class="border-bottom border-dark"
+                                                            >
+                                                                <td
+                                                                    class="text-muted"
+                                                                >
+                                                                    Select All
+                                                                </td>
+                                                                <td
+                                                                    v-for="(
+                                                                        taxonomy_id,
+                                                                        i
+                                                                    ) in split_species_taxonomy_ids"
+                                                                    :key="i"
+                                                                    class="text-center"
+                                                                    :style="{
+                                                                        width:
+                                                                            abbrColPercent +
+                                                                            '%',
+                                                                    }"
+                                                                >
+                                                                    <div
+                                                                        class="form-check form-check-inline"
+                                                                    >
+                                                                        <input
+                                                                            type="checkbox"
+                                                                            class="form-check-input mt-2"
+                                                                            @change="
+                                                                                toggleSelectAll(
+                                                                                    $event,
+                                                                                    taxonomy_id
+                                                                                )
+                                                                            "
+                                                                            :checked="
+                                                                                selectAllCheckedState[
+                                                                                    uniqueScientificNames[
+                                                                                        i
+                                                                                    ]
+                                                                                        .slug
+                                                                                ]
+                                                                            "
+                                                                        />
+                                                                    </div>
+                                                                </td>
+                                                            </tr>
+                                                            <tr
+                                                                v-for="occurrence in occurrences"
+                                                                :key="
+                                                                    occurrence.id
+                                                                "
+                                                                :id="
+                                                                    'occurrence-' +
+                                                                    occurrence.id
+                                                                "
+                                                                class="occurrence-assignment-row"
+                                                            >
+                                                                <td
+                                                                    class="abbr-nowrap small"
+                                                                    :title="
+                                                                        occurrence.occurrence_name
+                                                                    "
+                                                                >
+                                                                    {{
+                                                                        occurrence.occurrence_number
+                                                                    }}
+                                                                    -
+                                                                    {{
+                                                                        occurrence.occurrence_name
+                                                                    }}
+                                                                </td>
+                                                                <td
+                                                                    v-for="(
+                                                                        taxonomyId,
+                                                                        index
+                                                                    ) in split_species_taxonomy_ids"
+                                                                    :key="index"
+                                                                    class="text-center"
+                                                                    :style="{
+                                                                        width:
+                                                                            abbrColPercent +
+                                                                            '%',
+                                                                    }"
+                                                                >
+                                                                    <div
+                                                                        class="form-check form-check-inline"
+                                                                    >
+                                                                        <input
+                                                                            type="checkbox"
+                                                                            :name="
+                                                                                'occurrence:' +
+                                                                                occurrence.id
+                                                                            "
+                                                                            :checked="
+                                                                                assignmentCheckedState[
+                                                                                    occurrence
+                                                                                        .id
+                                                                                ] ===
+                                                                                taxonomyId
+                                                                            "
+                                                                            @change="
+                                                                                onOccurrenceCheckboxChange(
+                                                                                    occurrence.id,
+                                                                                    taxonomyId,
+                                                                                    $event
+                                                                                )
+                                                                            "
+                                                                            class="form-check-input mt-2"
+                                                                            :data-slug="
                                                                                 uniqueScientificNames[
-                                                                                    i
+                                                                                    index
                                                                                 ]
                                                                                     .slug
-                                                                            ]
-                                                                        "
-                                                                    />
-                                                                </div>
-                                                            </td>
-                                                        </tr>
-                                                        <tr
-                                                            v-for="occurrence in occurrences"
-                                                            :key="occurrence.id"
-                                                            :id="
-                                                                'occurrence-' +
-                                                                occurrence.id
-                                                            "
-                                                            class="occurrence-assignment-row"
-                                                        >
-                                                            <td
-                                                                class="abbr-nowrap small"
-                                                                :title="
-                                                                    occurrence.occurrence_name
-                                                                "
-                                                            >
-                                                                {{
-                                                                    occurrence.occurrence_number
-                                                                }}
-                                                                -
-                                                                {{
-                                                                    occurrence.occurrence_name
-                                                                }}
-                                                            </td>
-                                                            <td
-                                                                v-for="(
-                                                                    taxonomyId,
-                                                                    index
-                                                                ) in split_species_taxonomy_ids"
-                                                                :key="index"
-                                                                class="text-center"
-                                                                :style="{
-                                                                    width:
-                                                                        abbrColPercent +
-                                                                        '%',
-                                                                }"
-                                                            >
-                                                                <div
-                                                                    class="form-check form-check-inline"
-                                                                >
-                                                                    <input
-                                                                        type="checkbox"
-                                                                        :name="
-                                                                            'occurrence:' +
-                                                                            occurrence.id
-                                                                        "
-                                                                        :checked="
-                                                                            assignmentCheckedState[
-                                                                                occurrence
-                                                                                    .id
-                                                                            ] ===
-                                                                            taxonomyId
-                                                                        "
-                                                                        @change="
-                                                                            onOccurrenceCheckboxChange(
-                                                                                occurrence.id,
-                                                                                taxonomyId,
-                                                                                $event
-                                                                            )
-                                                                        "
-                                                                        class="form-check-input mt-2"
-                                                                        :data-slug="
-                                                                            uniqueScientificNames[
-                                                                                index
-                                                                            ]
-                                                                                .slug
-                                                                        "
-                                                                    />
-                                                                </div>
-                                                            </td>
-                                                        </tr>
-                                                    </tbody>
-                                                </table>
+                                                                            "
+                                                                        />
+                                                                    </div>
+                                                                </td>
+                                                            </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </div>
                                             </div>
                                             <template v-else>
                                                 <div


### PR DESCRIPTION
- Update rename species email template to match rework
- Adjust rename species so that it overwrites the data in the resulting species with data from the original species
- Add a scrollable div to the split species assign occurrences tab to support any number of occurrences