### PR TITLE
Build fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 **/*.csv
 **/*.xls*
 
-.git
 .gitignore
 node_modules
 venv


### PR DESCRIPTION
Allow .git for now as we are still copying git repo to image and usin…g to get git hash (should consider passing git commit in via the pipeline build command instead to avoid that).