### PR TITLE
Data Migration

### DIFF
--- a/boranga/components/data_migration/PARTITION_MIGRATION_DATA.md
+++ b/boranga/components/data_migration/PARTITION_MIGRATION_DATA.md
@@ -11,7 +11,7 @@ python3 scripts/partition_migration_data.py \
  --output private-media/legacy_data/TPFL/species-profiles-partitioned.csv \
  --report private-media/legacy_data/TPFL/species-profiles-partitioned-report.csv \
  --max-cardinality 100 \
- --heaviest-first
+ --heaviest-last
 
 Once the business users have done their data verification, run the full migration of species with the --wipe-targets flag and then move on to the next migration run.
 
@@ -23,7 +23,7 @@ python3 scripts/partition_migration_data.py \
  --output private-media/legacy_data/TPFL/occurrences-partitioned.csv \
  --report private-media/legacy_data/TPFL/occurrences-report.csv \
  --max-cardinality 100 \
- --heaviest-first
+ --heaviest-last
 
 python3 scripts/partition_migration_data.py \
  --adapter boranga.components.data_migration.adapters.occurrence_report.tpfl.OccurrenceReportTpflAdapter \
@@ -31,4 +31,4 @@ python3 scripts/partition_migration_data.py \
  --output private-media/legacy_data/TPFL/occurrence-reports-partitioned.csv \
  --report private-media/legacy_data/TPFL/occurrence-reports-report.csv \
  --max-cardinality 100 \
- --heaviest-first
+ --heaviest-last

--- a/boranga/components/data_migration/adapters/occurrence_report/tpfl.py
+++ b/boranga/components/data_migration/adapters/occurrence_report/tpfl.py
@@ -5,6 +5,7 @@ from boranga.components.data_migration.registry import (
     conditional_transform_factory,
     csv_lookup_factory,
     date_from_datetime_iso_factory,
+    datetime_iso_factory,
     dependent_from_column_factory,
     emailuser_by_legacy_username_factory,
     emailuser_object_by_legacy_username_factory,
@@ -57,6 +58,8 @@ GEOMETRY_LOCKED_DEFAULT = static_value_factory(True)
 SPECIES_TRANSFORM = taxonomy_lookup_legacy_mapping_species("TPFL")
 
 COMMUNITY_TRANSFORM = fk_lookup(model=Community, lookup_field="community_name")
+
+DATETIME_ISO_PERTH = datetime_iso_factory("Australia/Perth")
 
 
 def map_form_status_code_to_processing_status(value: str, ctx=None) -> str | None:
@@ -523,7 +526,7 @@ PIPELINES = {
     "Occurrence__migrated_from_id": [OCCURRENCE_FROM_POP_ID_TRANSFORM],
     "species_id": ["strip", "blank_to_none", SPECIES_TRANSFORM],
     "community_id": ["strip", "blank_to_none", COMMUNITY_TRANSFORM],
-    "lodgement_date": ["strip", "blank_to_none", "datetime_iso"],
+    "lodgement_date": ["strip", "blank_to_none", DATETIME_ISO_PERTH],
     "observation_date": ["strip", "blank_to_none", DATE_FROM_DATETIME_ISO_PERTH],
     "record_source": ["strip", "blank_to_none", RECORD_SOURCE_FROM_CSV],
     "customer_status": [CUSTOMER_STATUS_FROM_FORM_STATUS_CODE],

--- a/boranga/components/data_migration/adapters/species/tpfl.py
+++ b/boranga/components/data_migration/adapters/species/tpfl.py
@@ -2,6 +2,7 @@ from boranga.components.data_migration.mappings import get_group_type_id
 from boranga.components.data_migration.registry import (
     choices_transform,
     date_from_datetime_iso_factory,
+    datetime_iso_factory,
     emailuser_by_legacy_username_factory,
     registry,
     taxonomy_lookup_legacy_id_mapping,
@@ -23,6 +24,8 @@ EMAILUSER_BY_LEGACY_USERNAME_TRANSFORM = emailuser_by_legacy_username_factory("T
 
 DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_factory("Australia/Perth")
 
+DATETIME_ISO_PERTH = datetime_iso_factory("Australia/Perth")
+
 PROCESSING_STATUS = choices_transform([c[0] for c in Species.PROCESSING_STATUS_CHOICES])
 
 PIPELINES = {
@@ -40,7 +43,7 @@ PIPELINES = {
     "conservation_plan_exists": ["strip", "blank_to_none", "is_present"],
     "department_file_numbers": ["strip", "blank_to_none"],
     "last_data_curation_date": ["strip", "blank_to_none", DATE_FROM_DATETIME_ISO_PERTH],
-    "lodgement_date": ["strip", "blank_to_none", "datetime_iso"],
+    "lodgement_date": ["strip", "blank_to_none", DATETIME_ISO_PERTH],
     "processing_status": [
         "strip",
         "blank_to_none",
@@ -51,7 +54,7 @@ PIPELINES = {
     "submitter": ["strip", "blank_to_none", EMAILUSER_BY_LEGACY_USERNAME_TRANSFORM],
     "distribution": ["strip", "blank_to_none"],
     "modified_by": ["strip", "blank_to_none", EMAILUSER_BY_LEGACY_USERNAME_TRANSFORM],
-    "datetime_updated": ["strip", "blank_to_none", "datetime_iso"],
+    "datetime_updated": ["strip", "blank_to_none", DATETIME_ISO_PERTH],
 }
 
 

--- a/scripts/partition_migration_data.py
+++ b/scripts/partition_migration_data.py
@@ -116,6 +116,7 @@ def partition_data(
     ignore_fields: list[str],
     max_cardinality: int = 50,
     heaviest_first: bool = False,
+    heaviest_last: bool = False,
     report_path: str = None,
 ):
     logger.info(f"Loading adapter: {adapter_path}")
@@ -255,7 +256,10 @@ def partition_data(
 
     logger.info(f"Selected {len(selected_indices)} rows out of {len(df)}.")
 
-    if not heaviest_first:
+    if heaviest_last:
+        selected_rows_info.reverse()
+        selected_indices = [x[0] for x in selected_rows_info]
+    elif not heaviest_first:
         # Sort by index to preserve relative order roughly
         selected_rows_info.sort(key=lambda x: x[0])
         selected_indices = [x[0] for x in selected_rows_info]
@@ -317,6 +321,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Sort output by number of new features covered (descending)",
     )
+    parser.add_argument(
+        "--heaviest-last",
+        action="store_true",
+        help="Sort output by number of new features covered (ascending)",
+    )
 
     parser.add_argument(
         "--report",
@@ -334,5 +343,6 @@ if __name__ == "__main__":
         ignore_list,
         args.max_cardinality,
         args.heaviest_first,
+        args.heaviest_last,
         args.report,
     )


### PR DESCRIPTION
Fix three datetime formatting transformations that were missed
Modify record paritioning script such that the most populated records can be last rather than first (since records in Boranga are displayed in descending order by default)