### PR TITLE
Data Migration & UAT Feedback

### DIFF
--- a/boranga/components/conservation_status/models.py
+++ b/boranga/components/conservation_status/models.py
@@ -480,6 +480,8 @@ class ConservationStatus(LockableModel, SubmitterInformationModelMixin, Revision
         ("species", "Species"),
         ("community", "Community"),
         ("agendaitem", "Meeting Agenda Item"),
+        ("occurrences", "Occurrence"),
+        ("occurrence_report", "Occurrence Report"),
     ]
 
     # group_type of application

--- a/boranga/components/data_migration/adapters/occurrence/tpfl.py
+++ b/boranga/components/data_migration/adapters/occurrence/tpfl.py
@@ -6,7 +6,7 @@ from boranga.components.data_migration.mappings import get_group_type_id
 from boranga.components.data_migration.registry import (
     build_legacy_map_transform,
     choices_transform,
-    date_from_datetime_iso_factory,
+    date_from_datetime_iso_local_factory,
     datetime_iso_factory,
     emailuser_by_legacy_username_factory,
     fk_lookup,
@@ -25,7 +25,7 @@ from ..sources import Source
 # TPFL-specific transform bindings
 TAXONOMY_TRANSFORM = taxonomy_lookup_legacy_mapping("TPFL")
 DATETIME_ISO_PERTH = datetime_iso_factory("Australia/Perth")
-DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_factory("Australia/Perth")
+DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_local_factory("Australia/Perth")
 
 COORD_SOURCE_TRANSFORM = build_legacy_map_transform(
     legacy_system="TPFL",

--- a/boranga/components/data_migration/adapters/occurrence_report/tec_survey_threats.py
+++ b/boranga/components/data_migration/adapters/occurrence_report/tec_survey_threats.py
@@ -10,7 +10,7 @@ from boranga.components.data_migration.adapters.base import (
 from boranga.components.data_migration.adapters.sources import Source
 from boranga.components.data_migration.registry import (
     build_legacy_map_transform,
-    date_from_datetime_iso_factory,
+    date_from_datetime_iso_local_factory,
     lookup_model_value_factory,
     static_value_factory,
 )
@@ -24,7 +24,7 @@ CURRENT_IMPACT_FALLBACK = lookup_model_value_factory("CurrentImpact", "name", "U
 
 POTENTIAL_IMPACT_FALLBACK = lookup_model_value_factory("PotentialImpact", "name", "Unknown")
 
-DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_factory("Australia/Perth")
+DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_local_factory("Australia/Perth")
 
 
 class OccurrenceReportTecSurveyThreatsAdapter(SourceAdapter):

--- a/boranga/components/data_migration/adapters/occurrence_report/threats.py
+++ b/boranga/components/data_migration/adapters/occurrence_report/threats.py
@@ -10,14 +10,14 @@ from boranga.components.data_migration.registry import (
     TransformIssue,
     _result,
     build_legacy_map_transform,
-    date_from_datetime_iso_factory,
+    date_from_datetime_iso_local_factory,
     static_value_factory,
 )
 from boranga.components.occurrence.models import OccurrenceReport, OCRConservationThreat
 
 from ..sources import Source
 
-DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_factory("Australia/Perth")
+DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_local_factory("Australia/Perth")
 
 
 def preload_observation_dates(path: str) -> dict[str, str]:

--- a/boranga/components/data_migration/adapters/occurrence_report/tpfl.py
+++ b/boranga/components/data_migration/adapters/occurrence_report/tpfl.py
@@ -4,7 +4,7 @@ from boranga.components.data_migration.registry import (
     build_legacy_map_transform,
     conditional_transform_factory,
     csv_lookup_factory,
-    date_from_datetime_iso_factory,
+    date_from_datetime_iso_local_factory,
     datetime_iso_factory,
     dependent_from_column_factory,
     emailuser_by_legacy_username_factory,
@@ -42,7 +42,7 @@ OCCURRENCE_NUMBER_FROM_POP_ID = occurrence_number_from_pop_id_factory("TPFL")
 # Create factory transform that maps SHEETNO to POP_ID directly
 POP_ID_FROM_SHEETNO = pop_id_from_sheetno_factory("TPFL")
 
-DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_factory("Australia/Perth")
+DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_local_factory("Australia/Perth")
 
 # Create factory transform for geometry from coordinates
 GEOMETRY_FROM_COORDS = geometry_from_coords_factory(

--- a/boranga/components/data_migration/adapters/occurrence_threats/tpfl.py
+++ b/boranga/components/data_migration/adapters/occurrence_threats/tpfl.py
@@ -3,7 +3,7 @@ from boranga.components.data_migration.registry import (
     TransformResult,
     _result,
     build_legacy_map_transform,
-    date_from_datetime_iso_factory,
+    date_from_datetime_iso_local_factory,
     registry,
     static_value_factory,
 )
@@ -14,7 +14,7 @@ from ..base import ExtractionResult, ExtractionWarning, SourceAdapter
 from ..sources import Source
 from . import schema
 
-DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_factory("Australia/Perth")
+DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_local_factory("Australia/Perth")
 
 
 @registry.register("current_impact_fallback")

--- a/boranga/components/data_migration/adapters/species/tpfl.py
+++ b/boranga/components/data_migration/adapters/species/tpfl.py
@@ -1,7 +1,7 @@
 from boranga.components.data_migration.mappings import get_group_type_id
 from boranga.components.data_migration.registry import (
     choices_transform,
-    date_from_datetime_iso_factory,
+    date_from_datetime_iso_local_factory,
     datetime_iso_factory,
     emailuser_by_legacy_username_factory,
     registry,
@@ -22,7 +22,7 @@ TAXONOMY_TRANSFORM = taxonomy_lookup_legacy_id_mapping("TPFL")
 
 EMAILUSER_BY_LEGACY_USERNAME_TRANSFORM = emailuser_by_legacy_username_factory("TPFL")
 
-DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_factory("Australia/Perth")
+DATE_FROM_DATETIME_ISO_PERTH = date_from_datetime_iso_local_factory("Australia/Perth")
 
 DATETIME_ISO_PERTH = datetime_iso_factory("Australia/Perth")
 

--- a/boranga/components/occurrence/models.py
+++ b/boranga/components/occurrence/models.py
@@ -1036,6 +1036,7 @@ class OccurrenceReport(SubmitterInformationModelMixin, RevisionedMixin):
         if new_occurrence_name:
             # Check for existing Occurrences with the same name for the same Species/Community
             qs_occurrence = Occurrence.objects.filter(occurrence_name=new_occurrence_name)
+            group_type_text = "Species" if self.species else "Community"
             if self.species:
                 qs_occurrence = qs_occurrence.filter(species=self.species)
             elif self.community:
@@ -1043,7 +1044,7 @@ class OccurrenceReport(SubmitterInformationModelMixin, RevisionedMixin):
 
             if qs_occurrence.exists():
                 raise ValidationError(
-                    f'Occurrence with name "{new_occurrence_name}" already exists for this Species/Community'
+                    f"Occurrence with name {new_occurrence_name} already exists for this {group_type_text}"
                 )
 
             # Check for pending proposals (with approver) with the same name for the same Species/Community

--- a/boranga/components/occurrence/permissions.py
+++ b/boranga/components/occurrence/permissions.py
@@ -231,7 +231,9 @@ class OccurrenceReportObjectPermission(BasePermission):
                     return False
             elif view.basename == "occurrencereportdocument":
                 # Allow for referees to upload documents
-                if not is_occurrence_report_referee(request, occurrence_report=occurrence_report):
+                if is_occurrence_report_referee(request, occurrence_report=occurrence_report):
+                    pass
+                elif not self.is_authorised_to_update(request, occurrence_report):
                     return False
             elif not self.is_authorised_to_update(request, occurrence_report):
                 return False

--- a/boranga/components/species_and_communities/models.py
+++ b/boranga/components/species_and_communities/models.py
@@ -1547,7 +1547,12 @@ class Community(RevisionedMixin):
         (PROCESSING_STATUS_ACTIVE, "Active"),
         (PROCESSING_STATUS_HISTORICAL, "Historical"),
     )
-    RELATED_ITEM_CHOICES = [("conservation_status", "Conservation Status")]
+    RELATED_ITEM_CHOICES = [
+        ("community", "Community"),
+        ("conservation_status", "Conservation Status"),
+        ("occurrences", "Occurrence"),
+        ("occurrence_report", "Occurrence Report"),
+    ]
 
     community_number = models.CharField(max_length=9, blank=True, default="")
     renamed_from = models.ForeignKey(
@@ -1776,6 +1781,11 @@ class Community(RevisionedMixin):
                 "renamed_to",
                 "conservation_status",
                 "occurrences",
+            ]
+        elif filter_type == "community":
+            related_field_names = [
+                "renamed_from",
+                "renamed_to",
             ]
         else:
             related_field_names = [

--- a/boranga/components/species_and_communities/utils.py
+++ b/boranga/components/species_and_communities/utils.py
@@ -22,6 +22,7 @@ from boranga.components.species_and_communities.models import (
     CommunityUserAction,
     ConservationThreat,
     District,
+    GroupType,
     Region,
     Species,
     SpeciesConservationAttributes,
@@ -38,6 +39,9 @@ def species_form_submit(species_instance, request, split=False, rename=False):
     if not split and not rename:
         if not species_instance.can_user_edit:
             raise ValidationError("You can't submit this species at this moment")
+
+    if species_instance.group_type.name == GroupType.GROUP_TYPE_FAUNA and not species_instance.fauna_group:
+        raise ValidationError("Fauna Group is required before activating.")
 
     species_instance.submitter = request.user.id
     species_instance.lodgement_date = timezone.now()

--- a/boranga/frontend/boranga/src/components/common/conservation_status/species_status.vue
+++ b/boranga/frontend/boranga/src/components/common/conservation_status/species_status.vue
@@ -102,7 +102,7 @@
                         <input
                             id="previous_name"
                             v-model="taxon_previous_name"
-                            readonly
+                            disabled
                             type="text"
                             class="form-control"
                             placeholder=""

--- a/boranga/frontend/boranga/src/components/common/species_communities/species_profile.vue
+++ b/boranga/frontend/boranga/src/components/common/species_communities/species_profile.vue
@@ -241,8 +241,12 @@
                 <template v-if="species_community.group_type === 'fauna'">
                     <div class="row mb-3">
                         <div class="col-sm-3">
-                            <label for="fauna_group" class="control-label"
-                                >Fauna Group</label
+                            <label
+                                for="fauna_group"
+                                class="control-label fw-bold"
+                                >Fauna Group<span class="text-danger"
+                                    >*</span
+                                ></label
                             >
                         </div>
                         <div class="col-sm-9">

--- a/boranga/frontend/boranga/src/components/internal/occurrence/ocr_propose_approve.vue
+++ b/boranga/frontend/boranga/src/components/internal/occurrence/ocr_propose_approve.vue
@@ -455,7 +455,6 @@ export default {
             $(vm.$refs.occurrence_name_lookup_propose_approve)
                 .select2({
                     width: '100%',
-                    minimumInputLength: 2,
                     dropdownParent: $(
                         '#occurrence_name_lookup_propose_approve_form_group_id'
                     ),

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_communities.vue
@@ -1303,6 +1303,14 @@ export default {
                 }
             }
             if (check_action == 'submit') {
+                if (vm.species_community.group_type == 'fauna') {
+                    if (
+                        vm.species_community.fauna_group == null ||
+                        vm.species_community.fauna_group == ''
+                    ) {
+                        blank_fields.push(' Fauna Group is required');
+                    }
+                }
                 if (vm.species_community.group_type == 'community') {
                     if (
                         vm.species_community.taxonomy_details.community_name ==


### PR DESCRIPTION
Fix transformation of plain dates in TPFL and TEC migration runs

Uat Feedback tasks:

Task | 13463 | UAT Community ORF propose approve to new OCC   - cannot progress (error claims OCC Name already in use, but isn't)
Task | 13993 | Bug: Related Items filter not working as expected
Task | 13873 | Bug: ORF: Error attaching documents when in status With Assessor
Task | 14218 | SC UAT Fauna Prof - Fauna Group to be Mandatory
Task | 14764 | CS Previous Name field should be displayed as read only (grey)
Task | 13904 | CS External Contributor unable to view submitted CS Proposal
Task | 13992 | Species Rename and Combine: automation to rename related ORFs that are   NOT Approved (i.e. no linked OCC)
