### PR TITLE
UAT Tasks

### DIFF
--- a/boranga/components/main/models.py
+++ b/boranga/components/main/models.py
@@ -495,6 +495,48 @@ class HelpTextEntry(ArchivableModel):
     def __str__(self):
         return self.section_id
 
+    @classmethod
+    def get_helptext_entries(cls, use_cache: bool = True) -> dict:
+        """
+        Return a mapping of `section_id` -> attributes for active help text entries.
+
+        The result is cached using `settings.CACHE_KEY_HELP_TEXT_ENTRIES` and
+        cached for `CACHE_TIMEOUT_24_HOURS` by default.
+        """
+        cache_key = settings.CACHE_KEY_HELP_TEXT_ENTRIES
+        if use_cache:
+            cached = cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        rows = cls.objects.active().values(
+            "section_id",
+            "text",
+            "icon_with_popover",
+            "authenticated_users_only",
+            "internal_users_only",
+        )
+        result = {
+            r["section_id"]: {
+                "text": r["text"],
+                "icon_with_popover": r["icon_with_popover"],
+                "authenticated_users_only": r["authenticated_users_only"],
+                "internal_users_only": r["internal_users_only"],
+            }
+            for r in rows
+        }
+
+        cache.set(cache_key, result, settings.CACHE_TIMEOUT_NEVER)
+        return result
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        cache.delete(settings.CACHE_KEY_HELP_TEXT_ENTRIES)
+
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+        cache.delete(settings.CACHE_KEY_HELP_TEXT_ENTRIES)
+
 
 class AbstractOrderedListManager(OrderedModelManager):
     def active(self):

--- a/boranga/frontend/boranga/src/components/common/view_document.vue
+++ b/boranga/frontend/boranga/src/components/common/view_document.vue
@@ -117,6 +117,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        titleProperty: {
+            type: String,
+            default: 'document_number',
+        },
     },
     data() {
         return {
@@ -127,7 +131,7 @@ export default {
     computed: {
         title() {
             let documentNumber = this.document
-                ? this.document.document_number
+                ? this.document[this.titleProperty]
                 : '';
             return `View Document ${documentNumber}`;
         },

--- a/boranga/frontend/boranga/src/components/internal/meetings/meeting_section.vue
+++ b/boranga/frontend/boranga/src/components/internal/meetings/meeting_section.vue
@@ -284,6 +284,7 @@
                         v-model="meeting_obj.location"
                         type="text"
                         readonly
+                        disabled
                         class="form-control"
                         placeholder=""
                     />

--- a/boranga/frontend/boranga/src/components/internal/meetings/minutes.vue
+++ b/boranga/frontend/boranga/src/components/internal/meetings/minutes.vue
@@ -39,6 +39,7 @@
         <ViewDocument
             ref="view_document"
             :is_internal="is_internal"
+            title-property="minutes_number"
         ></ViewDocument>
         <div v-if="minutesHistoryId">
             <MinutesHistory

--- a/boranga/settings.py
+++ b/boranga/settings.py
@@ -319,7 +319,7 @@ if len(GIT_COMMIT_HASH) == 0:
         if len(GIT_COMMIT_HASH) == 0:
             print("ERROR: No git hash provided")
 
-APPLICATION_VERSION = env("APPLICATION_VERSION", "1.0.0")
+CONTAINER_IMAGE_TAG = env("CONTAINER_IMAGE_TAG", "CONTAINER_IMAGE_TAG ENV Not Set")
 
 RUNNING_DEVSERVER = len(sys.argv) > 1 and sys.argv[1] == "runserver"
 
@@ -335,7 +335,7 @@ if not RUNNING_DEVSERVER and SENTRY_DSN and EMAIL_INSTANCE:
         sample_rate=SENTRY_SAMPLE_RATE,
         traces_sample_rate=SENTRY_TRANSACTION_SAMPLE_RATE,
         environment=EMAIL_INSTANCE.lower(),
-        release=APPLICATION_VERSION,
+        release=CONTAINER_IMAGE_TAG,
     )
 
 LEDGER_UI_ACCOUNTS_MANAGEMENT = [

--- a/boranga/settings.py
+++ b/boranga/settings.py
@@ -245,8 +245,8 @@ MEDIA_APP_DIR = env("MEDIA_APP_DIR", "boranga")
 CRON_RUN_AT_TIMES = env("CRON_RUN_AT_TIMES", "04:05")
 CRON_EMAIL = env("CRON_EMAIL", "cron@" + SITE_DOMAIN).lower()
 EMAIL_FROM = DEFAULT_FROM_EMAIL
-# Time of day to run the import cadastre geojson cron job. Read from env or default to 03:00
-IMPORT_CADASTRE_GEOJSON_TIME_OF_DAY = env("IMPORT_CADASTRE_GEOJSON_TIME_OF_DAY", "03:00")
+# Time of day to run the import cadastre geojson cron job. Read from env or default to 04:00
+IMPORT_CADASTRE_GEOJSON_TIME_OF_DAY = env("IMPORT_CADASTRE_GEOJSON_TIME_OF_DAY", "04:00")
 
 CRON_CLASSES = [
     "appmonitor_client.cron.CronJobAppMonitorClient",

--- a/boranga/settings.py
+++ b/boranga/settings.py
@@ -436,6 +436,7 @@ CACHE_KEY_USER_BELONGS_TO_GROUP = "user-{user_id}-belongs-to-{group_name}"
 CACHE_KEY_USER_IS_REFEREE = "user-{user_id}-is-referee-{model}-{pk}"
 CACHE_KEY_SUPERUSER_IDS = "superuser-ids"
 CACHE_KEY_FILE_EXTENSION_WHITELIST = "file-extension-whitelist"
+CACHE_KEY_HELP_TEXT_ENTRIES = "helptext-entries"
 CACHE_KEY_PLAUSIBILITY_GEOMETRY = "plausibility-geometry-{geometry_model}"
 
 # ---------- Conservation Change Codes ----------

--- a/boranga/templates/boranga/base.html
+++ b/boranga/templates/boranga/base.html
@@ -70,13 +70,13 @@
 {% endblock %}
 
 {% block footer %}
-  {% application_version as application_version %}
+  {% container_image_tag as container_image_tag %}
   {% support_email as support_email %}
   <footer class="footer fixed-bottom mt-3">
     <div class="container-fluid border-top py-2 bg-light text-secondary">
       <div class="row">
         <div class="col">
-          <small class="float-start">Version:{% application_version %}</small>
+          <small class="float-start">Version: {% container_image_tag %}</small>
         </div>
         <div class="col">
           <small>Support: <a href="mailto:{% support_email %}">{% support_email %}</a></small>

--- a/boranga/templates/ledgerui/accounts_pris_message.html
+++ b/boranga/templates/ledgerui/accounts_pris_message.html
@@ -1,4 +1,4 @@
-{% load users %}
+{% load users utils %}
 
 {% is_internal as is_internal_login %}
 
@@ -9,13 +9,7 @@
             class="bi bi-info-circle-fill text-primary fs-4 flex-shrink-0"
         ></i>
         <div class="notice-body">
-            <p class="mb-0">
-                The Department of Biodiversity, Conservation and Attractions (DBCA) collects this personal information to contact you in relation to your access to Boranga.</p>
-            <p class="mb-0">We may share this information with other organisations/individuals, in order to advise of your validity of access to this database.</p>
-            <p class="mb-0">If you choose not to provide contact details, we will be unable to grant access to this database.</p>
-            <p class="mb-0">For further details on how DBCA manage your personal information, you can read our <a href="https://www.dbca.wa.gov.au/about-us/legislation/corporate-policies" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
-                If you have any questions about how your personal information will be handled, or if you would like to access your personal information, please contact DBCA at <a href="mailto:privacy@dbca.wa.gov.au">privacy@dbca.wa.gov.au</a>.
-            </p>
+            {% help_text_entry 'pris_collection_notice' %}
         </div>
     </div>
 </div>

--- a/boranga/templatetags/utils.py
+++ b/boranga/templatetags/utils.py
@@ -24,8 +24,8 @@ def help_text_entry(section_id):
 
 
 @register.simple_tag()
-def application_version():
-    return settings.APPLICATION_VERSION
+def container_image_tag():
+    return settings.CONTAINER_IMAGE_TAG
 
 
 @register.simple_tag()

--- a/boranga/templatetags/utils.py
+++ b/boranga/templatetags/utils.py
@@ -7,9 +7,20 @@ from django.contrib.staticfiles import finders
 from django.template import Library
 from django.utils.safestring import mark_safe
 
+from boranga.components.main.models import HelpTextEntry
+
 logger = logging.getLogger(__name__)
 
 register = Library()
+
+
+@register.simple_tag()
+def help_text_entry(section_id):
+    """Return the cached help text for a given section_id as safe HTML, or empty string."""
+    entry = HelpTextEntry.get_helptext_entries().get(section_id)
+    if not entry:
+        return ""
+    return mark_safe(entry["text"])
 
 
 @register.simple_tag()


### PR DESCRIPTION
- Make sure custom Boranga PRIS test on accounts page is retrieved from the DB so it updates when the users update it in django admin
- Tweak default run time of cadastre layer copy so that it doesn't overlap with the NOMOS sync
- make the location input disabled when in read only states since the readonly attribute alone still looks editable
- Allow specifying the title property as for the minutes view document modal the property is minutes_number rather than the usual document_number