### PR TITLE
History Mismatch Diagnose and Fix

### DIFF
--- a/boranga/components/data_migration/history_cleanup/reversion_cleanup.py
+++ b/boranga/components/data_migration/history_cleanup/reversion_cleanup.py
@@ -290,6 +290,7 @@ class ReversionHistoryCleaner:
             Total versions deleted across all models
         """
         from boranga.components.occurrence.models import (
+            OCCAnimalObservation,
             OCCAssociatedSpecies,
             OCCConservationThreat,
             OCCContactDetail,
@@ -299,6 +300,7 @@ class ReversionHistoryCleaner:
             OCCIdentification,
             OCCLocation,
             OCCObservationDetail,
+            OCCPlantCount,
             Occurrence,
             OccurrenceDocument,
             OccurrenceGeometry,
@@ -340,6 +342,8 @@ class ReversionHistoryCleaner:
             (OCCLocation, "occurrence"),
             (OccurrenceSite, "occurrence"),
             (OCCObservationDetail, "occurrence"),
+            (OCCPlantCount, "occurrence"),
+            (OCCAnimalObservation, "occurrence"),
             (OCCHabitatComposition, "occurrence"),
             (OCCFireHistory, "occurrence"),
             (OCCAssociatedSpecies, "occurrence"),

--- a/boranga/components/data_migration/history_cleanup/reversion_cleanup.py
+++ b/boranga/components/data_migration/history_cleanup/reversion_cleanup.py
@@ -315,6 +315,7 @@ class ReversionHistoryCleaner:
             OCRHabitatComposition,
             OCRHabitatCondition,
             OCRIdentification,
+            OCRLocation,
             OCRObservationDetail,
             OCRObserverDetail,
             OCRPlantCount,
@@ -368,6 +369,7 @@ class ReversionHistoryCleaner:
             (OCRPlantCount, "occurrence_report"),
             (OCRAnimalObservation, "occurrence_report"),
             (OCRIdentification, "occurrence_report"),
+            (OCRLocation, "occurrence_report"),
             (OccurrenceReportDocument, "occurrence_report"),
             (OCRConservationThreat, "occurrence_report"),
         ]
@@ -405,6 +407,7 @@ class ReversionHistoryCleaner:
             OCRHabitatComposition,
             OCRHabitatCondition,
             OCRIdentification,
+            OCRLocation,
             OCRObservationDetail,
             OCRObserverDetail,
             OCRPlantCount,
@@ -429,6 +432,7 @@ class ReversionHistoryCleaner:
             (OCRPlantCount, "occurrence_report"),
             (OCRAnimalObservation, "occurrence_report"),
             (OCRIdentification, "occurrence_report"),
+            (OCRLocation, "occurrence_report"),
             (OccurrenceReportDocument, "occurrence_report"),
             (OCRConservationThreat, "occurrence_report"),
         ]

--- a/boranga/components/data_migration/history_seeding/reversion_seeder.py
+++ b/boranga/components/data_migration/history_seeding/reversion_seeder.py
@@ -592,6 +592,78 @@ class MigratedHistorySeeder:
         )
         return set(existing)
 
+    def _clear_stale_migrated_from_id_versions(
+        self,
+        model_class: type[models.Model],
+        versioned_ids: set[str],
+    ) -> set[str]:
+        """
+        Among *versioned_ids*, find PKs where at least one Version's serialised
+        ``migrated_from_id`` differs from the live record's current value — the
+        signature of PK reuse after a wipe that left orphan Versions behind.
+
+        All Version rows for those PKs are deleted so the caller can re-seed
+        them with correct current data.  Returns the set of affected string PKs.
+
+        Implemented as a single Postgres-side JSON comparison; returns an empty
+        set without touching the DB on non-Postgres backends or for models that
+        have no ``migrated_from_id`` column.
+        """
+        from django.db import connection
+
+        if not versioned_ids:
+            return set()
+
+        # Only applicable to models with a direct migrated_from_id column.
+        try:
+            model_class._meta.get_field("migrated_from_id")
+        except Exception:
+            return set()
+
+        # The ::json operator used below is Postgres-specific.
+        if getattr(connection, "vendor", None) != "postgresql":
+            return set()
+
+        ct = ContentType.objects.get_for_model(model_class)
+        table = model_class._meta.db_table
+        id_list = list(versioned_ids)
+
+        # Find PKs where any Version's serialised migrated_from_id doesn't
+        # match the live column value.  IS DISTINCT FROM handles NULLs correctly.
+        sql = f"""
+            SELECT DISTINCT v.object_id
+            FROM   reversion_version v
+            JOIN   {table} m ON m.id = v.object_id::bigint
+            WHERE  v.content_type_id = %s
+              AND  v.object_id = ANY(%s)
+              AND  (v.serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id')
+                   IS DISTINCT FROM m.migrated_from_id
+        """  # nosec B608 — table name sourced from model._meta.db_table, not user input
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql, [ct.pk, id_list])
+            stale_ids = {row[0] for row in cursor.fetchall()}
+
+        if not stale_ids:
+            return set()
+
+        logger.warning(
+            "_clear_stale(%s): %d PK(s) have stale migrated_from_id in reversion history "
+            "(PK reuse after a wipe that left orphan Version rows) — deleting stale "
+            "Version rows so they will be re-seeded with correct data.",
+            model_class.__name__,
+            len(stale_ids),
+        )
+        deleted_count, _ = Version.objects.filter(content_type=ct, object_id__in=stale_ids).delete()
+        logger.info(
+            "_clear_stale(%s): deleted %d Version row(s) for %d stale PK(s)",
+            model_class.__name__,
+            deleted_count,
+            len(stale_ids),
+        )
+        self._stats[f"{model_class.__name__}_stale_cleared"] = len(stale_ids)
+        return stale_ids
+
     def _seed_simple_objects(
         self,
         queryset: models.QuerySet,
@@ -720,6 +792,14 @@ class MigratedHistorySeeder:
 
         str_ids = [str(pk) for pk in all_ids]
         already = self._already_versioned_ids(model_class, str_ids)
+
+        # Detect and remove stale versions caused by PK reuse after a wipe that
+        # left orphan Version rows behind.  Stale PKs are re-added to to_seed_pks
+        # so the correct current data is used for the baseline revision.
+        stale = self._clear_stale_migrated_from_id_versions(model_class, already)
+        if stale:
+            already -= stale
+
         to_seed_pks = [pk for pk, s in zip(all_ids, str_ids) if s not in already]
 
         if not to_seed_pks:

--- a/scripts/diagnose_occurrence_history_migrated_from_id.py
+++ b/scripts/diagnose_occurrence_history_migrated_from_id.py
@@ -1,0 +1,90 @@
+"""
+Diagnose Occurrence reversion history where the migrated_from_id stored in
+the Version serialised data does not match the current record value.
+
+This is the Occurrence equivalent of diagnose_tfauna_history_migrated_from_id.py.
+Run it before applying the stale-version fix in prod to see whether any
+Occurrence Version rows are stale and would be deleted + re-seeded.
+
+Run with:
+    python manage.py shell < scripts/diagnose_occurrence_history_migrated_from_id.py
+
+Output: occurrence_history_migrated_from_id_mismatch.csv in the project root.
+
+Summary lines printed to stdout:
+  - total mismatch Version rows  (what _clear_stale_migrated_from_id_versions would delete)
+  - distinct Occurrence PKs affected    (how many Occurrences would be re-seeded)
+"""
+
+import csv
+import os
+import sys
+
+try:
+    from django.conf import settings
+    from django.contrib.contenttypes.models import ContentType
+    from django.db import connection
+
+    from boranga.components.occurrence.models import Occurrence
+except Exception as exc:
+    print(f"Import failed: {exc}", file=sys.stderr)
+    raise
+
+OUTPUT_PATH = os.path.join(settings.BASE_DIR, "occurrence_history_migrated_from_id_mismatch.csv")
+
+occ_ct = ContentType.objects.get_for_model(Occurrence)
+print(f"Occurrence content_type_id = {occ_ct.pk}")
+print("Running database-side comparison (this should be fast) ...")
+
+# Extract migrated_from_id directly from the JSON blob in Postgres and compare
+# to the live column value in a single query — no Python-side JSON parsing needed.
+#
+# serialized_data is a JSON array:  [{"model": ..., "fields": {"migrated_from_id": "...", ...}}]
+# Postgres JSON path:  serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id'
+SQL = """
+    SELECT
+        occ.id                                                              AS occ_pk,
+        occ.occurrence_number,
+        occ.migrated_from_id                                               AS current_migrated_from_id,
+        (v.serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id') AS history_migrated_from_id,
+        v.id                                                               AS version_pk,
+        r.date_created                                                     AS revision_date,
+        r.comment                                                          AS revision_comment
+    FROM boranga_occurrence occ
+    JOIN reversion_version  v ON v.object_id       = occ.id::text
+                              AND v.content_type_id = %s
+    JOIN reversion_revision r ON r.id              = v.revision_id
+    WHERE occ.migrated_from_id IS NOT NULL
+      AND occ.migrated_from_id <> ''
+      AND (v.serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id')
+          IS DISTINCT FROM occ.migrated_from_id
+    ORDER BY occ.id, r.date_created;
+"""
+
+with connection.cursor() as cursor:
+    cursor.execute(SQL, [occ_ct.pk])
+    columns = [col[0] for col in cursor.description]
+    rows = cursor.fetchall()
+
+print(f"Query complete. {len(rows):,} mismatch(es) found.")
+
+if not rows:
+    print("No mismatches — all Occurrence history entries match current migrated_from_id values.")
+    sys.exit(0)
+
+with open(OUTPUT_PATH, "w", newline="", encoding="utf-8") as f:
+    writer = csv.writer(f)
+    writer.writerow(columns)
+    writer.writerows(rows)
+
+unique_occs = len({r[0] for r in rows})
+# Each stale Occurrence PK may have multiple Version rows (one per follow-relation
+# in the reversion.register() follow list).  _clear_stale_migrated_from_id_versions
+# deletes ALL Version rows for stale PKs, so the total version count below is
+# the upper bound on rows that would be deleted if the fix runs in prod.
+print(f"Found {len(rows):,} mismatched version(s) across {unique_occs:,} Occurrence(s).")
+print(
+    f"If the seeder stale-fix runs in prod, up to {len(rows):,} Version rows would be "
+    f"deleted and {unique_occs:,} Occurrence(s) re-seeded with correct history."
+)
+print(f"Output written to: {OUTPUT_PATH}")

--- a/scripts/diagnose_tec_history_migrated_from_id.py
+++ b/scripts/diagnose_tec_history_migrated_from_id.py
@@ -1,0 +1,91 @@
+"""
+Diagnose TEC/community OccurrenceReport reversion history where the
+migrated_from_id stored in the Version serialised data does not match
+the current record value.
+
+This is the same check as diagnose_tfauna_history_migrated_from_id.py but
+scoped to records whose migrated_from_id begins with 'tec-'.  Run it before
+applying the stale-version fix in prod to estimate how many Version rows would
+be deleted.
+
+Run with:
+    python manage.py shell < scripts/diagnose_tec_history_migrated_from_id.py
+
+Output: tec_history_migrated_from_id_mismatch.csv in the project root.
+
+Summary lines printed to stdout:
+  - total mismatch Version rows  (what _clear_stale_migrated_from_id_versions would delete)
+  - distinct OCR PKs affected    (how many OCRs would be re-seeded)
+"""
+
+import csv
+import os
+import sys
+
+try:
+    from django.conf import settings
+    from django.contrib.contenttypes.models import ContentType
+    from django.db import connection
+
+    from boranga.components.occurrence.models import OccurrenceReport
+except Exception as exc:
+    print(f"Import failed: {exc}", file=sys.stderr)
+    raise
+
+OUTPUT_PATH = os.path.join(settings.BASE_DIR, "tec_history_migrated_from_id_mismatch.csv")
+
+ocr_ct = ContentType.objects.get_for_model(OccurrenceReport)
+print(f"OccurrenceReport content_type_id = {ocr_ct.pk}")
+print("Running database-side comparison (this should be fast) ...")
+
+# Extract migrated_from_id directly from the JSON blob in Postgres and compare
+# to the live column value in a single query — no Python-side JSON parsing needed.
+#
+# serialized_data is a JSON array:  [{"model": ..., "fields": {"migrated_from_id": "...", ...}}]
+# Postgres JSON path:  serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id'
+SQL = """
+    SELECT
+        ocr.id                                                              AS ocr_pk,
+        ocr.occurrence_report_number,
+        ocr.migrated_from_id                                               AS current_migrated_from_id,
+        (v.serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id') AS history_migrated_from_id,
+        v.id                                                               AS version_pk,
+        r.date_created                                                     AS revision_date,
+        r.comment                                                          AS revision_comment
+    FROM boranga_occurrencereport ocr
+    JOIN reversion_version  v ON v.object_id       = ocr.id::text
+                              AND v.content_type_id = %s
+    JOIN reversion_revision r ON r.id              = v.revision_id
+    WHERE ocr.migrated_from_id ILIKE 'tec-%%'
+      AND (v.serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id')
+          IS DISTINCT FROM ocr.migrated_from_id
+    ORDER BY ocr.id, r.date_created;
+"""
+
+with connection.cursor() as cursor:
+    cursor.execute(SQL, [ocr_ct.pk])
+    columns = [col[0] for col in cursor.description]
+    rows = cursor.fetchall()
+
+print(f"Query complete. {len(rows):,} mismatch(es) found.")
+
+if not rows:
+    print("No mismatches — all TEC OCR history entries match current migrated_from_id values.")
+    sys.exit(0)
+
+with open(OUTPUT_PATH, "w", newline="", encoding="utf-8") as f:
+    writer = csv.writer(f)
+    writer.writerow(columns)
+    writer.writerows(rows)
+
+unique_ocrs = len({r[0] for r in rows})
+# Each stale OCR PK may have multiple Version rows (one per follow-relation in
+# the reversion.register() follow list).  _clear_stale_migrated_from_id_versions
+# deletes ALL Version rows for stale PKs, so the total version count below is
+# the upper bound on rows that would be deleted if the fix runs in prod.
+print(f"Found {len(rows):,} mismatched version(s) across {unique_ocrs:,} OCR(s).")
+print(
+    f"If the seeder stale-fix runs in prod, up to {len(rows):,} Version rows would be "
+    f"deleted and {unique_ocrs:,} OCR(s) re-seeded with correct history."
+)
+print(f"Output written to: {OUTPUT_PATH}")

--- a/scripts/diagnose_tfauna_history_migrated_from_id.py
+++ b/scripts/diagnose_tfauna_history_migrated_from_id.py
@@ -1,0 +1,73 @@
+"""
+Diagnose TFAUNA OccurrenceReport reversion history where the migrated_from_id
+stored in the Version serialised data does not match the current record value.
+
+Run with:
+    python manage.py shell < scripts/diagnose_tfauna_history_migrated_from_id.py
+
+Output: tfauna_history_migrated_from_id_mismatch.csv in the project root.
+"""
+
+import csv
+import os
+import sys
+
+try:
+    from django.conf import settings
+    from django.contrib.contenttypes.models import ContentType
+    from django.db import connection
+
+    from boranga.components.occurrence.models import OccurrenceReport
+except Exception as exc:
+    print(f"Import failed: {exc}", file=sys.stderr)
+    raise
+
+OUTPUT_PATH = os.path.join(settings.BASE_DIR, "tfauna_history_migrated_from_id_mismatch.csv")
+
+ocr_ct = ContentType.objects.get_for_model(OccurrenceReport)
+print(f"OccurrenceReport content_type_id = {ocr_ct.pk}")
+print("Running database-side comparison (this should be fast) ...")
+
+# Extract migrated_from_id directly from the JSON blob in Postgres and compare
+# to the live column value in a single query — no Python-side JSON parsing needed.
+#
+# serialized_data is a JSON array:  [{"model": ..., "fields": {"migrated_from_id": "...", ...}}]
+# Postgres JSON path:  serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id'
+SQL = """
+    SELECT
+        ocr.id                                                              AS ocr_pk,
+        ocr.occurrence_report_number,
+        ocr.migrated_from_id                                               AS current_migrated_from_id,
+        (v.serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id') AS history_migrated_from_id,
+        v.id                                                               AS version_pk,
+        r.date_created                                                     AS revision_date,
+        r.comment                                                          AS revision_comment
+    FROM boranga_occurrencereport ocr
+    JOIN reversion_version  v ON v.object_id       = ocr.id::text
+                              AND v.content_type_id = %s
+    JOIN reversion_revision r ON r.id              = v.revision_id
+    WHERE ocr.migrated_from_id ILIKE 'tfauna-%%'
+      AND (v.serialized_data::json -> 0 -> 'fields' ->> 'migrated_from_id')
+          IS DISTINCT FROM ocr.migrated_from_id
+    ORDER BY ocr.id, r.date_created;
+"""
+
+with connection.cursor() as cursor:
+    cursor.execute(SQL, [ocr_ct.pk])
+    columns = [col[0] for col in cursor.description]
+    rows = cursor.fetchall()
+
+print(f"Query complete. {len(rows):,} mismatch(es) found.")
+
+if not rows:
+    print("No mismatches — all TFAUNA OCR history entries match current migrated_from_id values.")
+    sys.exit(0)
+
+with open(OUTPUT_PATH, "w", newline="", encoding="utf-8") as f:
+    writer = csv.writer(f)
+    writer.writerow(columns)
+    writer.writerows(rows)
+
+unique_ocrs = len({r[0] for r in rows})
+print(f"Found {len(rows):,} mismatched version(s) across {unique_ocrs:,} OCR(s).")
+print(f"Output written to: {OUTPUT_PATH}")


### PR DESCRIPTION
- Add scripts to generate reports regarding mismatched reversion history items
- Add missing children records to history seeder
- Add mismatch detection to history seeder that will remove the existing record if the migrated_from_id doesn't match