### PR TITLE
Fix: Rename, split and combine db performance

### DIFF
--- a/boranga/components/data_migration/handlers/occurrence_reports.py
+++ b/boranga/components/data_migration/handlers/occurrence_reports.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry, Polygon
-from django.core.cache import cache
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models as dj_models
 from django.db import transaction
@@ -5317,8 +5316,6 @@ class OccurrenceReportImporter(BaseSheetImporter):
                         "Fixed ocr_for_occ_number for OCRs linked to %d new Occurrences",
                         len(pending_ids),
                     )
-                    # Also clear the cache once (not per-row)
-                    cache.delete(settings.CACHE_KEY_MAP_OCCURRENCES)
 
             # Bulk-update changed Occurrences
             occ_updated = 0

--- a/boranga/components/occurrence/models.py
+++ b/boranga/components/occurrence/models.py
@@ -3955,8 +3955,6 @@ class Occurrence(DirtyFieldsMixin, LockableModel, RevisionedMixin):
         app_label = "boranga"
 
     def save(self, *args, version_user=None, **kwargs):
-        # Clear the cache
-        cache.delete(settings.CACHE_KEY_MAP_OCCURRENCES)
         if version_user is not None:
             user_id = version_user.id if hasattr(version_user, "id") else int(version_user)
             self.last_modified_by = user_id

--- a/boranga/components/occurrence/models.py
+++ b/boranga/components/occurrence/models.py
@@ -2559,16 +2559,18 @@ class OCRHabitatComposition(BaseModel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._meta.get_field("land_form").choices = tuple(
-            LandForm.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
-        self._meta.get_field("soil_type").choices = tuple(
-            SoilType.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
+        if not self._meta.get_field("land_form").choices:
+            self._meta.get_field("land_form").choices = tuple(
+                LandForm.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
+        if not self._meta.get_field("soil_type").choices:
+            self._meta.get_field("soil_type").choices = tuple(
+                SoilType.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
 
 
 class OCRHabitatCondition(BaseModel):
@@ -3448,21 +3450,24 @@ class OCRAnimalObservation(BaseModel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._meta.get_field("primary_detection_method").choices = tuple(
-            PrimaryDetectionMethod.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
-        self._meta.get_field("secondary_sign").choices = tuple(
-            SecondarySign.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
-        self._meta.get_field("reproductive_state").choices = tuple(
-            ReproductiveState.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
+        if not self._meta.get_field("primary_detection_method").choices:
+            self._meta.get_field("primary_detection_method").choices = tuple(
+                PrimaryDetectionMethod.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
+        if not self._meta.get_field("secondary_sign").choices:
+            self._meta.get_field("secondary_sign").choices = tuple(
+                SecondarySign.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
+        if not self._meta.get_field("reproductive_state").choices:
+            self._meta.get_field("reproductive_state").choices = tuple(
+                ReproductiveState.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
 
     def save(self, *args, **kwargs):
         if self.occurrence_report.migrated_from_id:
@@ -5150,16 +5155,18 @@ class OCCHabitatComposition(BaseModel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._meta.get_field("land_form").choices = tuple(
-            LandForm.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
-        self._meta.get_field("soil_type").choices = tuple(
-            SoilType.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
+        if not self._meta.get_field("land_form").choices:
+            self._meta.get_field("land_form").choices = tuple(
+                LandForm.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
+        if not self._meta.get_field("soil_type").choices:
+            self._meta.get_field("soil_type").choices = tuple(
+                SoilType.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
 
 
 class OCCHabitatCondition(BaseModel):
@@ -5590,21 +5597,24 @@ class OCCAnimalObservation(BaseModel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._meta.get_field("primary_detection_method").choices = tuple(
-            PrimaryDetectionMethod.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
-        self._meta.get_field("secondary_sign").choices = tuple(
-            SecondarySign.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
-        self._meta.get_field("reproductive_state").choices = tuple(
-            ReproductiveState.objects.annotate(
-                id_str=Cast("id", CharField()),
-            ).values_list("id_str", "name")
-        )
+        if not self._meta.get_field("primary_detection_method").choices:
+            self._meta.get_field("primary_detection_method").choices = tuple(
+                PrimaryDetectionMethod.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
+        if not self._meta.get_field("secondary_sign").choices:
+            self._meta.get_field("secondary_sign").choices = tuple(
+                SecondarySign.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
+        if not self._meta.get_field("reproductive_state").choices:
+            self._meta.get_field("reproductive_state").choices = tuple(
+                ReproductiveState.objects.annotate(
+                    id_str=Cast("id", CharField()),
+                ).values_list("id_str", "name")
+            )
 
     def save(self, *args, **kwargs):
         if self.occurrence.migrated_from_id:

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -41,6 +41,7 @@ from boranga.components.occurrence.models import (
     OCCConservationThreat,
     Occurrence,
     OccurrenceReport,
+    OccurrenceReportUserAction,
     OccurrenceUserAction,
 )
 from boranga.components.occurrence.serializers import OCCConservationThreatSerializer
@@ -1781,6 +1782,15 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                 for tid, occ_ids in by_species.items():
                     target_species = species_map[tid]
 
+                    # Capture OCR IDs before update for version/log creation.
+                    updated_ocr_ids = list(
+                        OccurrenceReport.objects.filter(
+                            occurrence_id__in=occ_ids,
+                        )
+                        .exclude(species=target_species)
+                        .values_list("id", flat=True)
+                    )
+
                     # Update OCRs first (before occurrence update, to match update_child_ocrs logic)
                     OccurrenceReport.objects.filter(
                         occurrence_id__in=occ_ids,
@@ -1812,6 +1822,9 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                     # Bulk-create reversion versions and per-occurrence action logs.
                     old_name = instance.taxonomy.scientific_name if instance.taxonomy else str(instance)
                     new_name = target_species.taxonomy.scientific_name
+                    occ_number_map = dict(
+                        Occurrence.objects.filter(id__in=occ_ids).values_list("id", "occurrence_number")
+                    )
                     version_batch, log_batch = [], []
                     for occ, revision in zip(Occurrence.objects.filter(id__in=occ_ids).iterator(), revision_list):
                         version_batch.append(
@@ -1845,6 +1858,55 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                     if version_batch:
                         Version.objects.bulk_create(version_batch)
                         OccurrenceUserAction.objects.bulk_create(log_batch)
+
+                    # Bulk-create reversion versions and action logs for the updated OCRs.
+                    if updated_ocr_ids:
+                        ocr_ct = ContentType.objects.get_for_model(OccurrenceReport)
+                        ocr_revision_list = Revision.objects.bulk_create(
+                            [
+                                Revision(
+                                    date_created=now,
+                                    user=request.user,
+                                    comment=f"Split from {instance}",
+                                )
+                                for _ in updated_ocr_ids
+                            ]
+                        )
+                        version_batch, log_batch = [], []
+                        for ocr, revision in zip(
+                            OccurrenceReport.objects.filter(id__in=updated_ocr_ids).iterator(), ocr_revision_list
+                        ):
+                            version_batch.append(
+                                Version(
+                                    revision=revision,
+                                    object_id=str(ocr.pk),
+                                    content_type=ocr_ct,
+                                    db="default",
+                                    format="json",
+                                    serialized_data=dj_serializers.serialize("json", [ocr]),
+                                    object_repr=str(ocr),
+                                )
+                            )
+                            log_batch.append(
+                                OccurrenceReportUserAction(
+                                    occurrence_report=ocr,
+                                    who=user_id,
+                                    what=OccurrenceReportUserAction.ACTION_UPDATE_SPECIES_FROM_OCCURRENCE.format(
+                                        old_name,
+                                        new_name,
+                                        occ_number_map.get(ocr.occurrence_id, ocr.occurrence_id),
+                                    ),
+                                    when=now,
+                                )
+                            )
+                            if len(version_batch) >= 500:
+                                Version.objects.bulk_create(version_batch)
+                                OccurrenceReportUserAction.objects.bulk_create(log_batch)
+                                version_batch.clear()
+                                log_batch.clear()
+                        if version_batch:
+                            Version.objects.bulk_create(version_batch)
+                            OccurrenceReportUserAction.objects.bulk_create(log_batch)
 
         if not split_of_species_retains_original:
             # Set the original species from the split to historical and its conservation status to 'closed'
@@ -2089,9 +2151,12 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
 
         # Capture pre-update data (IDs and old species names) for action log creation.
         occ_pre_update = list(
-            Occurrence.objects.filter(species__in=combine_species_qs).values("id", "species__taxonomy__scientific_name")
+            Occurrence.objects.filter(species__in=combine_species_qs).values(
+                "id", "occurrence_number", "species__taxonomy__scientific_name"
+            )
         )
         moved_occ_ids = [row["id"] for row in occ_pre_update]
+        occ_number_map = {row["id"]: row["occurrence_number"] for row in occ_pre_update}
         occ_old_species_map = {row["id"]: (row["species__taxonomy__scientific_name"] or "") for row in occ_pre_update}
         new_combine_species_name = (
             resulting_species_instance.taxonomy.scientific_name
@@ -2101,6 +2166,14 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
 
         if moved_occ_ids:
             # 1. Update OCRs first (occurrences still point to old species — enables clean filter).
+            # Capture OCR IDs before update for version/log creation.
+            updated_ocr_ids = list(
+                OccurrenceReport.objects.filter(
+                    occurrence_id__in=moved_occ_ids,
+                )
+                .exclude(species=resulting_species_instance)
+                .values_list("id", flat=True)
+            )
             OccurrenceReport.objects.filter(
                 occurrence_id__in=moved_occ_ids,
             ).exclude(species=resulting_species_instance).update(
@@ -2161,6 +2234,55 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             if version_batch:
                 Version.objects.bulk_create(version_batch)
                 OccurrenceUserAction.objects.bulk_create(log_batch)
+
+            # 4. Bulk-create reversion versions and action logs for the updated OCRs.
+            if updated_ocr_ids:
+                ocr_ct = ContentType.objects.get_for_model(OccurrenceReport)
+                ocr_revision_list = Revision.objects.bulk_create(
+                    [
+                        Revision(
+                            date_created=now,
+                            user=request.user,
+                            comment=f"Combine into {resulting_species_instance}",
+                        )
+                        for _ in updated_ocr_ids
+                    ]
+                )
+                version_batch, log_batch = [], []
+                for ocr, revision in zip(
+                    OccurrenceReport.objects.filter(id__in=updated_ocr_ids).iterator(), ocr_revision_list
+                ):
+                    version_batch.append(
+                        Version(
+                            revision=revision,
+                            object_id=str(ocr.pk),
+                            content_type=ocr_ct,
+                            db="default",
+                            format="json",
+                            serialized_data=dj_serializers.serialize("json", [ocr]),
+                            object_repr=str(ocr),
+                        )
+                    )
+                    log_batch.append(
+                        OccurrenceReportUserAction(
+                            occurrence_report=ocr,
+                            who=user_id,
+                            what=OccurrenceReportUserAction.ACTION_UPDATE_SPECIES_FROM_OCCURRENCE.format(
+                                occ_old_species_map.get(ocr.occurrence_id, ""),
+                                new_combine_species_name,
+                                occ_number_map.get(ocr.occurrence_id, ocr.occurrence_id),
+                            ),
+                            when=now,
+                        )
+                    )
+                    if len(version_batch) >= 500:
+                        Version.objects.bulk_create(version_batch)
+                        OccurrenceReportUserAction.objects.bulk_create(log_batch)
+                        version_batch.clear()
+                        log_batch.clear()
+                if version_batch:
+                    Version.objects.bulk_create(version_batch)
+                    OccurrenceReportUserAction.objects.bulk_create(log_batch)
 
         #  send the combine species email notification
         send_species_combine_email_notification(request, combine_species_qs, resulting_species_instance, actions)
@@ -2238,12 +2360,21 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
 
         # Capture occurrence data before update for precise version/log creation.
         occ_log_data = list(Occurrence.objects.filter(species=instance).values_list("id", "occurrence_number"))
+        moved_occ_ids = [occ_id for occ_id, _ in occ_log_data]
+        occ_number_map = dict(occ_log_data)
         old_species_name = instance.taxonomy.scientific_name if instance.taxonomy else str(instance)
         new_species_name = (
             rename_instance.taxonomy.scientific_name if rename_instance.taxonomy else str(rename_instance)
         )
 
         # 1. Update OCRs first, while occurrences still point to `instance` (enables clean JOIN filter).
+        # Capture OCR IDs before the update for version/log creation.
+        updated_ocr_ids = list(
+            OccurrenceReport.objects.filter(
+                occurrence__species=instance,
+                species=instance,
+            ).values_list("id", flat=True)
+        )
         OccurrenceReport.objects.filter(
             occurrence__species=instance,
             species=instance,
@@ -2266,7 +2397,6 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         #    Only the occurrence's own fields changed, so child versions are not needed.
         #    One Revision per occurrence — a shared Revision causes GetRevisionVersionsView
         #    to return all N occurrences when viewing any single occurrence's history entry.
-        moved_occ_ids = [occ_id for occ_id, _ in occ_log_data]
         occurrence_ct = ContentType.objects.get_for_model(Occurrence)
         revision_list = Revision.objects.bulk_create(
             [
@@ -2312,6 +2442,55 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         if version_batch:
             Version.objects.bulk_create(version_batch)
             OccurrenceUserAction.objects.bulk_create(log_batch)
+
+        # 4. Bulk-create reversion Version rows and action logs for the updated OCRs.
+        if updated_ocr_ids:
+            ocr_ct = ContentType.objects.get_for_model(OccurrenceReport)
+            ocr_revision_list = Revision.objects.bulk_create(
+                [
+                    Revision(
+                        date_created=now,
+                        user=request.user,
+                        comment=f"Rename: species changed from {instance} to {rename_instance}",
+                    )
+                    for _ in updated_ocr_ids
+                ]
+            )
+            version_batch, log_batch = [], []
+            for ocr, revision in zip(
+                OccurrenceReport.objects.filter(id__in=updated_ocr_ids).iterator(), ocr_revision_list
+            ):
+                version_batch.append(
+                    Version(
+                        revision=revision,
+                        object_id=str(ocr.pk),
+                        content_type=ocr_ct,
+                        db="default",
+                        format="json",
+                        serialized_data=dj_serializers.serialize("json", [ocr]),
+                        object_repr=str(ocr),
+                    )
+                )
+                log_batch.append(
+                    OccurrenceReportUserAction(
+                        occurrence_report=ocr,
+                        who=user_id,
+                        what=OccurrenceReportUserAction.ACTION_UPDATE_SPECIES_FROM_OCCURRENCE.format(
+                            old_species_name,
+                            new_species_name,
+                            occ_number_map.get(ocr.occurrence_id, ocr.occurrence_id),
+                        ),
+                        when=now,
+                    )
+                )
+                if len(version_batch) >= BATCH_SIZE:
+                    Version.objects.bulk_create(version_batch)
+                    OccurrenceReportUserAction.objects.bulk_create(log_batch)
+                    version_batch.clear()
+                    log_batch.clear()
+            if version_batch:
+                Version.objects.bulk_create(version_batch)
+                OccurrenceReportUserAction.objects.bulk_create(log_batch)
 
         # Log action
         instance.log_user_action(

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -1825,6 +1825,11 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                     occ_number_map = dict(
                         Occurrence.objects.filter(id__in=occ_ids).values_list("id", "occurrence_number")
                     )
+                    # Pre-compute taxonomy version data for this target species.
+                    new_taxonomy = target_species.taxonomy
+                    taxonomy_ct = ContentType.objects.get_for_model(Taxonomy) if new_taxonomy else None
+                    taxonomy_data = dj_serializers.serialize("json", [new_taxonomy]) if new_taxonomy else None
+                    taxonomy_repr = str(new_taxonomy) if new_taxonomy else ""
                     version_batch, log_batch = [], []
                     for occ, revision in zip(Occurrence.objects.filter(id__in=occ_ids).iterator(), revision_list):
                         version_batch.append(
@@ -1858,6 +1863,24 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                     if version_batch:
                         Version.objects.bulk_create(version_batch)
                         OccurrenceUserAction.objects.bulk_create(log_batch)
+
+                    # Add taxonomy version to each occurrence revision.
+                    if taxonomy_ct and revision_list:
+                        Version.objects.bulk_create(
+                            [
+                                Version(
+                                    revision=rev,
+                                    object_id=str(new_taxonomy.pk),
+                                    content_type=taxonomy_ct,
+                                    db="default",
+                                    format="json",
+                                    serialized_data=taxonomy_data,
+                                    object_repr=taxonomy_repr,
+                                )
+                                for rev in revision_list
+                            ],
+                            batch_size=500,
+                        )
 
                     # Bulk-create reversion versions and action logs for the updated OCRs.
                     if updated_ocr_ids:
@@ -1907,6 +1930,24 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                         if version_batch:
                             Version.objects.bulk_create(version_batch)
                             OccurrenceReportUserAction.objects.bulk_create(log_batch)
+
+                        # Add taxonomy version to each OCR revision.
+                        if taxonomy_ct and ocr_revision_list:
+                            Version.objects.bulk_create(
+                                [
+                                    Version(
+                                        revision=rev,
+                                        object_id=str(new_taxonomy.pk),
+                                        content_type=taxonomy_ct,
+                                        db="default",
+                                        format="json",
+                                        serialized_data=taxonomy_data,
+                                        object_repr=taxonomy_repr,
+                                    )
+                                    for rev in ocr_revision_list
+                                ],
+                                batch_size=500,
+                            )
 
         if not split_of_species_retains_original:
             # Set the original species from the split to historical and its conservation status to 'closed'
@@ -2148,6 +2189,11 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         user_id = request.user.id if hasattr(request.user, "id") else int(request.user)
         now = timezone.now()
         occurrence_ct = ContentType.objects.get_for_model(Occurrence)
+        # Pre-compute taxonomy version data for the resulting species.
+        new_taxonomy = resulting_species_instance.taxonomy
+        taxonomy_ct = ContentType.objects.get_for_model(Taxonomy) if new_taxonomy else None
+        taxonomy_data = dj_serializers.serialize("json", [new_taxonomy]) if new_taxonomy else None
+        taxonomy_repr = str(new_taxonomy) if new_taxonomy else ""
 
         # Capture pre-update data (IDs and old species names) for action log creation.
         occ_pre_update = list(
@@ -2235,6 +2281,24 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                 Version.objects.bulk_create(version_batch)
                 OccurrenceUserAction.objects.bulk_create(log_batch)
 
+            # Add taxonomy version to each occurrence revision.
+            if taxonomy_ct and revision_list:
+                Version.objects.bulk_create(
+                    [
+                        Version(
+                            revision=rev,
+                            object_id=str(new_taxonomy.pk),
+                            content_type=taxonomy_ct,
+                            db="default",
+                            format="json",
+                            serialized_data=taxonomy_data,
+                            object_repr=taxonomy_repr,
+                        )
+                        for rev in revision_list
+                    ],
+                    batch_size=500,
+                )
+
             # 4. Bulk-create reversion versions and action logs for the updated OCRs.
             if updated_ocr_ids:
                 ocr_ct = ContentType.objects.get_for_model(OccurrenceReport)
@@ -2283,6 +2347,24 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                 if version_batch:
                     Version.objects.bulk_create(version_batch)
                     OccurrenceReportUserAction.objects.bulk_create(log_batch)
+
+                # Add taxonomy version to each OCR revision.
+                if taxonomy_ct and ocr_revision_list:
+                    Version.objects.bulk_create(
+                        [
+                            Version(
+                                revision=rev,
+                                object_id=str(new_taxonomy.pk),
+                                content_type=taxonomy_ct,
+                                db="default",
+                                format="json",
+                                serialized_data=taxonomy_data,
+                                object_repr=taxonomy_repr,
+                            )
+                            for rev in ocr_revision_list
+                        ],
+                        batch_size=500,
+                    )
 
         #  send the combine species email notification
         send_species_combine_email_notification(request, combine_species_qs, resulting_species_instance, actions)
@@ -2398,6 +2480,13 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         #    One Revision per occurrence — a shared Revision causes GetRevisionVersionsView
         #    to return all N occurrences when viewing any single occurrence's history entry.
         occurrence_ct = ContentType.objects.get_for_model(Occurrence)
+        # Pre-compute taxonomy version data (same for all occurrences in this rename).
+        # Adding a taxonomy Version to each revision populates data.data.taxonomy.fields.scientific_name
+        # in the history datatable without running _follow_relations per occurrence.
+        new_taxonomy = rename_instance.taxonomy
+        taxonomy_ct = ContentType.objects.get_for_model(Taxonomy) if new_taxonomy else None
+        taxonomy_data = dj_serializers.serialize("json", [new_taxonomy]) if new_taxonomy else None
+        taxonomy_repr = str(new_taxonomy) if new_taxonomy else ""
         revision_list = Revision.objects.bulk_create(
             [
                 Revision(
@@ -2442,6 +2531,24 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         if version_batch:
             Version.objects.bulk_create(version_batch)
             OccurrenceUserAction.objects.bulk_create(log_batch)
+
+        # Add taxonomy version to each occurrence revision (needed for scientific_name column in history).
+        if taxonomy_ct and revision_list:
+            Version.objects.bulk_create(
+                [
+                    Version(
+                        revision=rev,
+                        object_id=str(new_taxonomy.pk),
+                        content_type=taxonomy_ct,
+                        db="default",
+                        format="json",
+                        serialized_data=taxonomy_data,
+                        object_repr=taxonomy_repr,
+                    )
+                    for rev in revision_list
+                ],
+                batch_size=500,
+            )
 
         # 4. Bulk-create reversion Version rows and action logs for the updated OCRs.
         if updated_ocr_ids:
@@ -2491,6 +2598,24 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             if version_batch:
                 Version.objects.bulk_create(version_batch)
                 OccurrenceReportUserAction.objects.bulk_create(log_batch)
+
+            # Add taxonomy version to each OCR revision.
+            if taxonomy_ct and ocr_revision_list:
+                Version.objects.bulk_create(
+                    [
+                        Version(
+                            revision=rev,
+                            object_id=str(new_taxonomy.pk),
+                            content_type=taxonomy_ct,
+                            db="default",
+                            format="json",
+                            serialized_data=taxonomy_data,
+                            object_repr=taxonomy_repr,
+                        )
+                        for rev in ocr_revision_list
+                    ],
+                    batch_size=500,
+                )
 
         # Log action
         instance.log_user_action(

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -4,10 +4,13 @@ import mimetypes
 from datetime import datetime, timedelta
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.core import serializers as dj_serializers
 from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Exists, OuterRef, Q
 from django.http import HttpResponse
+from django.utils import timezone
 from rest_framework import mixins, serializers, status, views, viewsets
 from rest_framework.decorators import action as detail_route
 from rest_framework.decorators import action as list_route
@@ -17,6 +20,7 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework_datatables.filters import DatatablesFilterBackend
 from rest_framework_datatables.pagination import DatatablesPageNumberPagination
+from reversion.models import Revision, Version
 
 from boranga.components.conservation_status.models import (
     CommonwealthConservationList,
@@ -36,6 +40,7 @@ from boranga.components.occurrence.api import OCCConservationThreatFilterBackend
 from boranga.components.occurrence.models import (
     OCCConservationThreat,
     Occurrence,
+    OccurrenceReport,
     OccurrenceUserAction,
 )
 from boranga.components.occurrence.serializers import OCCConservationThreatSerializer
@@ -2110,13 +2115,58 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         # set the original species from the rename to historical
         rename_species_original_submit(instance, rename_instance, request)
 
-        # Change all occurrence records to point to the new species
-        occurrences = Occurrence.objects.filter(species=instance)
-        # Using a loop with .save here instead of a single .update so custom code runs that reassigns all
-        # OCRs to also point to the new species
-        for occurrence in occurrences:
-            occurrence.species = rename_instance
-            occurrence.save(version_user=request.user)
+        # Change all occurrence records to point to the new species.
+        # Bulk UPDATE instead of a per-object save loop — at scale (10k+ occurrences)
+        # the loop causes gunicorn worker timeouts. The rename action is logged at
+        # the species level, so per-occurrence revisions are not needed here.
+        user_id = request.user.id if hasattr(request.user, "id") else int(request.user)
+        now = timezone.now()
+
+        # 1. Update OCRs first, while occurrences still point to `instance` (enables clean JOIN filter).
+        OccurrenceReport.objects.filter(
+            occurrence__species=instance,
+            species=instance,
+        ).update(
+            species=rename_instance,
+            datetime_updated=now,
+            last_modified_by=user_id,
+        )
+
+        # 2. Bulk update occurrences.
+        Occurrence.objects.filter(species=instance).update(
+            species=rename_instance,
+            datetime_updated=now,
+            last_modified_by=user_id,
+        )
+
+        # 3. Bulk-create reversion Version rows for the updated occurrences.
+        #    We bypass add_to_revision() to avoid _follow_relations fetching all
+        #    child objects per occurrence (which is what caused the original timeout).
+        #    Only the occurrence's own fields changed, so child versions are not needed.
+        occurrence_ct = ContentType.objects.get_for_model(Occurrence)
+        revision = Revision.objects.create(
+            date_created=now,
+            user=request.user,
+            comment=(f"Bulk rename: species changed from {instance} to {rename_instance}"),
+        )
+        version_batch, BATCH_SIZE = [], 500
+        for occ in Occurrence.objects.filter(species=rename_instance).iterator():
+            version_batch.append(
+                Version(
+                    revision=revision,
+                    object_id=str(occ.pk),
+                    content_type=occurrence_ct,
+                    db="default",
+                    format="json",
+                    serialized_data=dj_serializers.serialize("json", [occ]),
+                    object_repr=str(occ),
+                )
+            )
+            if len(version_batch) >= BATCH_SIZE:
+                Version.objects.bulk_create(version_batch)
+                version_batch.clear()
+        if version_batch:
+            Version.objects.bulk_create(version_batch)
 
         # Log action
         instance.log_user_action(

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -1773,11 +1773,6 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                 # Phase 2: bulk UPDATE grouped by target species.
                 # Bulk UPDATE instead of per-occurrence .save() loop — same reasoning as rename_species.
                 occurrence_ct = ContentType.objects.get_for_model(Occurrence)
-                revision = Revision.objects.create(
-                    date_created=now,
-                    user=request.user,
-                    comment=f"Bulk split from {instance}",
-                )
 
                 by_species = {}
                 for occ_id, tid in moving.items():
@@ -1802,11 +1797,23 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                         last_modified_by=user_id,
                     )
 
+                    # One Revision per occurrence — see rename_species for explanation.
+                    revision_list = Revision.objects.bulk_create(
+                        [
+                            Revision(
+                                date_created=now,
+                                user=request.user,
+                                comment=f"Split from {instance}",
+                            )
+                            for _ in occ_ids
+                        ]
+                    )
+
                     # Bulk-create reversion versions and per-occurrence action logs.
                     old_name = instance.taxonomy.scientific_name if instance.taxonomy else str(instance)
                     new_name = target_species.taxonomy.scientific_name
                     version_batch, log_batch = [], []
-                    for occ in Occurrence.objects.filter(id__in=occ_ids).iterator():
+                    for occ, revision in zip(Occurrence.objects.filter(id__in=occ_ids).iterator(), revision_list):
                         version_batch.append(
                             Version(
                                 revision=revision,
@@ -2110,13 +2117,19 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             )
 
             # 3. Bulk-create reversion versions and per-occurrence action logs.
-            revision = Revision.objects.create(
-                date_created=now,
-                user=request.user,
-                comment=f"Bulk combine into {resulting_species_instance}",
+            # One Revision per occurrence — see rename_species for explanation.
+            revision_list = Revision.objects.bulk_create(
+                [
+                    Revision(
+                        date_created=now,
+                        user=request.user,
+                        comment=f"Combine into {resulting_species_instance}",
+                    )
+                    for _ in moved_occ_ids
+                ]
             )
             version_batch, log_batch = [], []
-            for occ in Occurrence.objects.filter(id__in=moved_occ_ids).iterator():
+            for occ, revision in zip(Occurrence.objects.filter(id__in=moved_occ_ids).iterator(), revision_list):
                 version_batch.append(
                     Version(
                         revision=revision,
@@ -2251,15 +2264,22 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         #    We bypass add_to_revision() to avoid _follow_relations fetching all
         #    child objects per occurrence (which is what caused the original timeout).
         #    Only the occurrence's own fields changed, so child versions are not needed.
+        #    One Revision per occurrence — a shared Revision causes GetRevisionVersionsView
+        #    to return all N occurrences when viewing any single occurrence's history entry.
         moved_occ_ids = [occ_id for occ_id, _ in occ_log_data]
         occurrence_ct = ContentType.objects.get_for_model(Occurrence)
-        revision = Revision.objects.create(
-            date_created=now,
-            user=request.user,
-            comment=(f"Bulk rename: species changed from {instance} to {rename_instance}"),
+        revision_list = Revision.objects.bulk_create(
+            [
+                Revision(
+                    date_created=now,
+                    user=request.user,
+                    comment=f"Rename: species changed from {instance} to {rename_instance}",
+                )
+                for _ in moved_occ_ids
+            ]
         )
         version_batch, log_batch, BATCH_SIZE = [], [], 500
-        for occ in Occurrence.objects.filter(id__in=moved_occ_ids).iterator():
+        for occ, revision in zip(Occurrence.objects.filter(id__in=moved_occ_ids).iterator(), revision_list):
             version_batch.append(
                 Version(
                     revision=revision,

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -2117,10 +2117,16 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
 
         # Change all occurrence records to point to the new species.
         # Bulk UPDATE instead of a per-object save loop — at scale (10k+ occurrences)
-        # the loop causes gunicorn worker timeouts. The rename action is logged at
-        # the species level, so per-occurrence revisions are not needed here.
+        # the loop causes gunicorn worker timeouts.
         user_id = request.user.id if hasattr(request.user, "id") else int(request.user)
         now = timezone.now()
+
+        # Capture occurrence data before update for precise version/log creation.
+        occ_log_data = list(Occurrence.objects.filter(species=instance).values_list("id", "occurrence_number"))
+        old_species_name = instance.taxonomy.scientific_name if instance.taxonomy else str(instance)
+        new_species_name = (
+            rename_instance.taxonomy.scientific_name if rename_instance.taxonomy else str(rename_instance)
+        )
 
         # 1. Update OCRs first, while occurrences still point to `instance` (enables clean JOIN filter).
         OccurrenceReport.objects.filter(
@@ -2139,18 +2145,19 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             last_modified_by=user_id,
         )
 
-        # 3. Bulk-create reversion Version rows for the updated occurrences.
+        # 3. Bulk-create reversion Version rows and per-occurrence action logs.
         #    We bypass add_to_revision() to avoid _follow_relations fetching all
         #    child objects per occurrence (which is what caused the original timeout).
         #    Only the occurrence's own fields changed, so child versions are not needed.
+        moved_occ_ids = [occ_id for occ_id, _ in occ_log_data]
         occurrence_ct = ContentType.objects.get_for_model(Occurrence)
         revision = Revision.objects.create(
             date_created=now,
             user=request.user,
             comment=(f"Bulk rename: species changed from {instance} to {rename_instance}"),
         )
-        version_batch, BATCH_SIZE = [], 500
-        for occ in Occurrence.objects.filter(species=rename_instance).iterator():
+        version_batch, log_batch, BATCH_SIZE = [], [], 500
+        for occ in Occurrence.objects.filter(id__in=moved_occ_ids).iterator():
             version_batch.append(
                 Version(
                     revision=revision,
@@ -2162,11 +2169,27 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                     object_repr=str(occ),
                 )
             )
+            log_batch.append(
+                OccurrenceUserAction(
+                    occurrence=occ,
+                    who=user_id,
+                    what=OccurrenceUserAction.ACTION_CHANGE_SPECIES_COMMUNITY.format(
+                        occ.occurrence_number,
+                        "species",
+                        old_species_name,
+                        new_species_name,
+                    ),
+                    when=now,
+                )
+            )
             if len(version_batch) >= BATCH_SIZE:
                 Version.objects.bulk_create(version_batch)
+                OccurrenceUserAction.objects.bulk_create(log_batch)
                 version_batch.clear()
+                log_batch.clear()
         if version_batch:
             Version.objects.bulk_create(version_batch)
+            OccurrenceUserAction.objects.bulk_create(log_batch)
 
         # Log action
         instance.log_user_action(

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -1734,54 +1734,110 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             if original_taxonomy_occurrence_count != len(occurrence_assignments_dict):
                 raise serializers.ValidationError("Invalid number of occurrence assignments.")
 
+            user_id = request.user.id if hasattr(request.user, "id") else int(request.user)
+            now = timezone.now()
+
+            # Phase 1: validate all assignments and build a mapping of occurrences
+            # that actually need to move (excluding same-species no-ops).
+            moving = {}  # occurrence_id (int) -> target taxonomy_id
             for occurrence_id, taxonomy_id in occurrence_assignments_dict.items():
-                # Process each assignment
                 if not occurrence_id:
                     raise serializers.ValidationError("Occurrence ID is missing in the assignment")
                 if not occurrence_id.isdigit():
                     raise serializers.ValidationError(f"Occurrence ID {occurrence_id} must be an integer")
-                occurrence = Occurrence.objects.filter(id=occurrence_id).first()
-                if not occurrence:
-                    raise serializers.ValidationError(f"Occurrence with ID {occurrence_id} does not exist")
-                # Get the taxonomy id from the assignment
                 if not taxonomy_id:
                     raise serializers.ValidationError(f"Taxonomy ID is missing for occurrence {occurrence_id}")
                 if not isinstance(taxonomy_id, int):
                     raise serializers.ValidationError(f"Taxonomy ID for occurrence {occurrence_id} must be an integer")
                 if taxonomy_id == instance.taxonomy_id:
-                    # No need to reassign the occurrence to the same species
-                    continue
+                    continue  # No change needed
+                moving[int(occurrence_id)] = taxonomy_id
 
-                taxonomy = Taxonomy.objects.filter(id=taxonomy_id).first()
-                if not taxonomy:
-                    raise serializers.ValidationError(f"Taxonomy with ID {taxonomy_id} does not exist")
-                species = Species.objects.filter(taxonomy_id=taxonomy_id).first()
-                if not species:
-                    raise serializers.ValidationError(f"Species with taxonomy ID {taxonomy_id} does not exist")
-                current_scientific_name = occurrence.species.taxonomy.scientific_name
-                # Assign the occurrence to the new species
-                occurrence.species = species
-                # When the occurrence is saved, the custom save method will
-                # reassign all OCRs to also point to the new species as well
-                occurrence.save(version_user=request.user)
+            if moving:
+                # Batch-validate occurrence existence (1 query instead of N)
+                existing_ids = set(Occurrence.objects.filter(id__in=moving.keys()).values_list("id", flat=True))
+                for occ_id in moving:
+                    if occ_id not in existing_ids:
+                        raise serializers.ValidationError(f"Occurrence with ID {occ_id} does not exist")
 
-                # Log the action
-                occurrence.log_user_action(
-                    OccurrenceUserAction.ACTION_CHANGE_OCCURRENCE_SPECIES_DUE_TO_SPLIT.format(
-                        occurrence.occurrence_number,
-                        current_scientific_name,
-                        species.taxonomy.scientific_name,
-                    ),
-                    request,
+                # Batch-validate species existence (1 query per unique taxonomy)
+                unique_tids = set(moving.values())
+                species_map = {
+                    s.taxonomy_id: s
+                    for s in Species.objects.filter(taxonomy_id__in=unique_tids).select_related("taxonomy")
+                }
+                for tid in unique_tids:
+                    if tid not in species_map:
+                        raise serializers.ValidationError(f"Species with taxonomy ID {tid} does not exist")
+
+                # Phase 2: bulk UPDATE grouped by target species.
+                # Bulk UPDATE instead of per-occurrence .save() loop — same reasoning as rename_species.
+                occurrence_ct = ContentType.objects.get_for_model(Occurrence)
+                revision = Revision.objects.create(
+                    date_created=now,
+                    user=request.user,
+                    comment=f"Bulk split from {instance}",
                 )
-                request.user.log_user_action(
-                    OccurrenceUserAction.ACTION_CHANGE_OCCURRENCE_SPECIES_DUE_TO_SPLIT.format(
-                        occurrence.occurrence_number,
-                        current_scientific_name,
-                        species.taxonomy.scientific_name,
-                    ),
-                    request,
-                )
+
+                by_species = {}
+                for occ_id, tid in moving.items():
+                    by_species.setdefault(tid, []).append(occ_id)
+
+                for tid, occ_ids in by_species.items():
+                    target_species = species_map[tid]
+
+                    # Update OCRs first (before occurrence update, to match update_child_ocrs logic)
+                    OccurrenceReport.objects.filter(
+                        occurrence_id__in=occ_ids,
+                    ).exclude(species=target_species).update(
+                        species=target_species,
+                        datetime_updated=now,
+                        last_modified_by=user_id,
+                    )
+
+                    # Bulk update occurrences
+                    Occurrence.objects.filter(id__in=occ_ids).update(
+                        species=target_species,
+                        datetime_updated=now,
+                        last_modified_by=user_id,
+                    )
+
+                    # Bulk-create reversion versions and per-occurrence action logs.
+                    old_name = instance.taxonomy.scientific_name if instance.taxonomy else str(instance)
+                    new_name = target_species.taxonomy.scientific_name
+                    version_batch, log_batch = [], []
+                    for occ in Occurrence.objects.filter(id__in=occ_ids).iterator():
+                        version_batch.append(
+                            Version(
+                                revision=revision,
+                                object_id=str(occ.pk),
+                                content_type=occurrence_ct,
+                                db="default",
+                                format="json",
+                                serialized_data=dj_serializers.serialize("json", [occ]),
+                                object_repr=str(occ),
+                            )
+                        )
+                        log_batch.append(
+                            OccurrenceUserAction(
+                                occurrence=occ,
+                                who=user_id,
+                                what=OccurrenceUserAction.ACTION_CHANGE_OCCURRENCE_SPECIES_DUE_TO_SPLIT.format(
+                                    occ.occurrence_number,
+                                    old_name,
+                                    new_name,
+                                ),
+                                when=now,
+                            )
+                        )
+                        if len(version_batch) >= 500:
+                            Version.objects.bulk_create(version_batch)
+                            OccurrenceUserAction.objects.bulk_create(log_batch)
+                            version_batch.clear()
+                            log_batch.clear()
+                    if version_batch:
+                        Version.objects.bulk_create(version_batch)
+                        OccurrenceUserAction.objects.bulk_create(log_batch)
 
         if not split_of_species_retains_original:
             # Set the original species from the split to historical and its conservation status to 'closed'

--- a/boranga/components/species_and_communities/api.py
+++ b/boranga/components/species_and_communities/api.py
@@ -2018,34 +2018,80 @@ class SpeciesViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                 request,
             )
 
-        # Reassign all occurrences for all the species being combined to the resulting species
-        occurrences = Occurrence.objects.filter(species__in=combine_species_qs)
+        # Reassign all occurrences for all the species being combined to the resulting species.
+        # Bulk UPDATE instead of a per-occurrence .save() loop — same reasoning as rename_species.
+        user_id = request.user.id if hasattr(request.user, "id") else int(request.user)
+        now = timezone.now()
+        occurrence_ct = ContentType.objects.get_for_model(Occurrence)
 
-        # Deliberately using a loop with .save here instead of a single .update
-        # so that custom code runs that reassigns all related OCRs to also point to the new species
-        for occurrence in occurrences:
-            current_scientific_name = occurrence.species.taxonomy.scientific_name
-            new_scientific_name = resulting_species_instance.taxonomy.scientific_name
-            occurrence.species = resulting_species_instance
-            occurrence.save(version_user=request.user)
+        # Capture pre-update data (IDs and old species names) for action log creation.
+        occ_pre_update = list(
+            Occurrence.objects.filter(species__in=combine_species_qs).values("id", "species__taxonomy__scientific_name")
+        )
+        moved_occ_ids = [row["id"] for row in occ_pre_update]
+        occ_old_species_map = {row["id"]: (row["species__taxonomy__scientific_name"] or "") for row in occ_pre_update}
+        new_combine_species_name = (
+            resulting_species_instance.taxonomy.scientific_name
+            if resulting_species_instance.taxonomy
+            else str(resulting_species_instance)
+        )
 
-            # Log the action
-            occurrence.log_user_action(
-                OccurrenceUserAction.ACTION_CHANGE_OCCURRENCE_SPECIES_DUE_TO_COMBINE.format(
-                    occurrence.occurrence_number,
-                    current_scientific_name,
-                    new_scientific_name,
-                ),
-                request,
+        if moved_occ_ids:
+            # 1. Update OCRs first (occurrences still point to old species — enables clean filter).
+            OccurrenceReport.objects.filter(
+                occurrence_id__in=moved_occ_ids,
+            ).exclude(species=resulting_species_instance).update(
+                species=resulting_species_instance,
+                datetime_updated=now,
+                last_modified_by=user_id,
             )
-            request.user.log_user_action(
-                OccurrenceUserAction.ACTION_CHANGE_OCCURRENCE_SPECIES_DUE_TO_COMBINE.format(
-                    occurrence.occurrence_number,
-                    current_scientific_name,
-                    new_scientific_name,
-                ),
-                request,
+
+            # 2. Bulk update occurrences.
+            Occurrence.objects.filter(id__in=moved_occ_ids).update(
+                species=resulting_species_instance,
+                datetime_updated=now,
+                last_modified_by=user_id,
             )
+
+            # 3. Bulk-create reversion versions and per-occurrence action logs.
+            revision = Revision.objects.create(
+                date_created=now,
+                user=request.user,
+                comment=f"Bulk combine into {resulting_species_instance}",
+            )
+            version_batch, log_batch = [], []
+            for occ in Occurrence.objects.filter(id__in=moved_occ_ids).iterator():
+                version_batch.append(
+                    Version(
+                        revision=revision,
+                        object_id=str(occ.pk),
+                        content_type=occurrence_ct,
+                        db="default",
+                        format="json",
+                        serialized_data=dj_serializers.serialize("json", [occ]),
+                        object_repr=str(occ),
+                    )
+                )
+                log_batch.append(
+                    OccurrenceUserAction(
+                        occurrence=occ,
+                        who=user_id,
+                        what=OccurrenceUserAction.ACTION_CHANGE_OCCURRENCE_SPECIES_DUE_TO_COMBINE.format(
+                            occ.occurrence_number,
+                            occ_old_species_map.get(occ.pk, ""),
+                            new_combine_species_name,
+                        ),
+                        when=now,
+                    )
+                )
+                if len(version_batch) >= 500:
+                    Version.objects.bulk_create(version_batch)
+                    OccurrenceUserAction.objects.bulk_create(log_batch)
+                    version_batch.clear()
+                    log_batch.clear()
+            if version_batch:
+                Version.objects.bulk_create(version_batch)
+                OccurrenceUserAction.objects.bulk_create(log_batch)
 
         #  send the combine species email notification
         send_species_combine_email_notification(request, combine_species_qs, resulting_species_instance, actions)

--- a/boranga/frontend/boranga/src/components/common/display_history.vue
+++ b/boranga/frontend/boranga/src/components/common/display_history.vue
@@ -46,7 +46,7 @@
                 </div>
                 <div v-if="loading" class="text-center py-4">
                     <span
-                        class="spinner-border spinner-border-sm me-2"
+                        class="spinner-border spinner-border-sm text-primary me-2"
                         role="status"
                         aria-hidden="true"
                     ></span>

--- a/boranga/frontend/boranga/src/components/common/display_history.vue
+++ b/boranga/frontend/boranga/src/components/common/display_history.vue
@@ -44,7 +44,16 @@
                 <div>
                     <strong>Data:</strong>
                 </div>
+                <div v-if="loading" class="text-center py-4">
+                    <span
+                        class="spinner-border spinner-border-sm me-2"
+                        role="status"
+                        aria-hidden="true"
+                    ></span>
+                    Loading…
+                </div>
                 <textarea
+                    v-else
                     disabled
                     class="form-control"
                     rows="25"
@@ -87,6 +96,7 @@ export default {
         return {
             isModalOpen: false,
             errorString: '',
+            loading: false,
             version_data: [],
             version_data_formatted: [],
             revision_date: '',
@@ -147,6 +157,7 @@ export default {
         },
         fetchHistoryData: function () {
             let vm = this;
+            vm.loading = true;
             fetch(
                 api_endpoints.lookup_revision_versions(
                     vm.primary_model,
@@ -159,8 +170,10 @@ export default {
                     vm.revision_user = data['revision_user'];
                     vm.version_data = data['version_data'];
                     vm.formatHistoryData();
+                    vm.loading = false;
                 },
                 (error) => {
+                    vm.loading = false;
                     console.log(error);
                 }
             );

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_combine.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_combine.vue
@@ -465,7 +465,7 @@ export default {
             this.pruneSelection();
             const confirm = await swal.fire({
                 title: 'Combine Species',
-                text: 'Are you sure you want to combine those species?',
+                html: '<p>Are you sure you want to combine these species?</p><p class="small text-muted">Note: Combining species that have many occurrences can take up to a minute</p>',
                 icon: 'question',
                 showCancelButton: true,
                 confirmButtonText: 'Combine Species',

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_combine.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_combine.vue
@@ -277,6 +277,7 @@
                     <button
                         type="button"
                         class="btn btn-secondary me-2"
+                        :disabled="submittingSpeciesCombine"
                         @click="cancel"
                     >
                         Cancel

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_rename.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_rename.vue
@@ -239,7 +239,7 @@ export default {
 
             const swalresult = await swal.fire({
                 title: 'Rename Species',
-                text: 'Are you sure you want to rename this species?',
+                html: '<p>Are you sure you want to rename this species?</p><p class="small text-muted">Note: Renaming a species that has many occurrences can take up to a minute</p>',
                 icon: 'question',
                 showCancelButton: true,
                 confirmButtonText: 'Rename Species',

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_rename.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_rename.vue
@@ -43,6 +43,7 @@
                     <button
                         type="button"
                         class="btn btn-secondary me-2"
+                        :disabled="submitSpeciesRename"
                         @click="cancel"
                     >
                         Cancel
@@ -53,7 +54,7 @@
                         style="margin-top: 5px"
                         disabled
                     >
-                        Submit
+                        Rename Species
                         <span
                             class="spinner-border spinner-border-sm"
                             role="status"
@@ -236,8 +237,7 @@ export default {
                 return false;
             }
 
-            vm.submitSpeciesRename = true;
-            swal.fire({
+            const swalresult = await swal.fire({
                 title: 'Rename Species',
                 text: 'Are you sure you want to rename this species?',
                 icon: 'question',
@@ -248,61 +248,59 @@ export default {
                     cancelButton: 'btn btn-secondary',
                 },
                 reverseButtons: true,
-            })
-                .then(async (swalresult) => {
-                    if (swalresult.isConfirmed) {
-                        fetch(
-                            helpers.add_endpoint_json(
-                                api_endpoints.species,
-                                vm.species_community_original.id +
-                                    '/rename_species'
-                            ),
-                            {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                },
-                                body: JSON.stringify(
-                                    vm.species_community_original_copy
-                                ),
-                            }
-                        ).then(
-                            async (response) => {
-                                const data = await response.json();
-                                if (!response.ok) {
-                                    swal.fire({
-                                        title: 'Submit Error',
-                                        text: JSON.stringify(data),
-                                        icon: 'error',
-                                        customClass: {
-                                            confirmButton: 'btn btn-primary',
-                                        },
-                                    });
-                                    vm.saveError = true;
-                                    return;
-                                }
-                                vm.new_species = data;
-                                vm.$router.push({
-                                    name: 'internal-species-communities-dash',
-                                });
-                            },
-                            (err) => {
-                                swal.fire({
-                                    title: 'Submit Error',
-                                    text: helpers.apiVueResourceError(err),
-                                    icon: 'error',
-                                    customClass: {
-                                        confirmButton: 'btn btn-primary',
-                                    },
-                                });
-                                vm.saveError = true;
-                            }
-                        );
+            });
+
+            if (!swalresult.isConfirmed) {
+                return;
+            }
+
+            vm.submitSpeciesRename = true;
+            try {
+                const response = await fetch(
+                    helpers.add_endpoint_json(
+                        api_endpoints.species,
+                        vm.species_community_original.id + '/rename_species'
+                    ),
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify(
+                            vm.species_community_original_copy
+                        ),
                     }
-                })
-                .finally(() => {
-                    vm.submitSpeciesRename = false;
+                );
+                const data = await response.json();
+                if (!response.ok) {
+                    swal.fire({
+                        title: 'Submit Error',
+                        text: JSON.stringify(data),
+                        icon: 'error',
+                        customClass: {
+                            confirmButton: 'btn btn-primary',
+                        },
+                    });
+                    vm.saveError = true;
+                    return;
+                }
+                vm.new_species = data;
+                vm.$router.push({
+                    name: 'internal-species-communities-dash',
                 });
+            } catch (err) {
+                swal.fire({
+                    title: 'Submit Error',
+                    text: helpers.apiVueResourceError(err),
+                    icon: 'error',
+                    customClass: {
+                        confirmButton: 'btn btn-primary',
+                    },
+                });
+                vm.saveError = true;
+            } finally {
+                vm.submitSpeciesRename = false;
+            }
         },
     },
 };

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_split.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_split.vue
@@ -500,6 +500,7 @@
                     <button
                         type="button"
                         class="btn btn-secondary me-2"
+                        :disabled="finalise_split_loading"
                         @click="cancel"
                     >
                         Cancel
@@ -785,7 +786,7 @@ export default {
                 occurrence_assignments: vm.assignmentCheckedState,
             };
             vm.submitSpeciesSplit = true;
-            swal.fire({
+            const swalresult = await swal.fire({
                 title: 'Split Species',
                 text: 'Are you sure you want to split this species?',
                 icon: 'question',
@@ -796,56 +797,43 @@ export default {
                     cancelButton: 'btn btn-secondary',
                 },
                 reverseButtons: true,
-            })
-                .then(async (swalresult) => {
-                    if (swalresult.isConfirmed) {
-                        vm.finalise_split_loading = true;
-                        let submit_url = helpers.add_endpoint_json(
-                            api_endpoints.species,
-                            vm.species_community_original.id + '/split_species'
-                        );
-                        fetch(submit_url, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify(payload),
-                        }).then(
-                            async (response) => {
-                                const data = await response.json();
-                                if (!response.ok) {
-                                    swal.fire({
-                                        title: 'Error',
-                                        text: JSON.stringify(data),
-                                        icon: 'error',
-                                        customClass: {
-                                            confirmButton: 'btn btn-primary',
-                                        },
-                                    });
-                                    return;
-                                }
-                                vm.$router.push({
-                                    name: 'internal-species-communities-dash',
-                                });
-                            },
-                            (err) => {
-                                swal.fire({
-                                    title: 'Submit Error',
-                                    text: helpers.apiVueResourceError(err),
-                                    icon: 'error',
-                                    customClass: {
-                                        confirmButton: 'btn btn-primary',
-                                    },
-                                });
-                                vm.saveError = true;
-                            }
-                        );
-                    }
-                })
-                .finally(() => {
-                    vm.finalise_split_loading = false;
-                    vm.submitSpeciesSplit = false;
+            });
+            vm.submitSpeciesSplit = false;
+            if (!swalresult.isConfirmed) return;
+
+            vm.finalise_split_loading = true;
+            try {
+                const submit_url = helpers.add_endpoint_json(
+                    api_endpoints.species,
+                    vm.species_community_original.id + '/split_species'
+                );
+                const response = await fetch(submit_url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
                 });
+                const data = await response.json();
+                if (!response.ok) {
+                    swal.fire({
+                        title: 'Error',
+                        text: JSON.stringify(data),
+                        icon: 'error',
+                        customClass: { confirmButton: 'btn btn-primary' },
+                    });
+                    return;
+                }
+                vm.$router.push({ name: 'internal-species-communities-dash' });
+            } catch (err) {
+                swal.fire({
+                    title: 'Submit Error',
+                    text: helpers.apiVueResourceError(err),
+                    icon: 'error',
+                    customClass: { confirmButton: 'btn btn-primary' },
+                });
+                vm.saveError = true;
+            } finally {
+                vm.finalise_split_loading = false;
+            }
         },
         addSpeciesTab: function () {
             let vm = this;

--- a/boranga/frontend/boranga/src/components/internal/species_communities/species_split.vue
+++ b/boranga/frontend/boranga/src/components/internal/species_communities/species_split.vue
@@ -185,7 +185,18 @@
                                             "
                                         >
                                             <div
-                                                v-if="
+                                                v-if="occurrencesLoading"
+                                                class="text-center py-4"
+                                            >
+                                                <span
+                                                    class="spinner-border spinner-border-sm text-primary me-2"
+                                                    role="status"
+                                                    aria-hidden="true"
+                                                ></span>
+                                                Loading occurrences…
+                                            </div>
+                                            <div
+                                                v-else-if="
                                                     occurrences &&
                                                     occurrences.length > 0
                                                 "
@@ -549,6 +560,7 @@ export default {
             submitSpeciesSplit: false,
             assignmentCheckedState: {},
             occurrences: null,
+            occurrencesLoading: false,
             isModalOpen: false,
             finalise_split_loading: false,
             split_species_list: [],
@@ -788,7 +800,7 @@ export default {
             vm.submitSpeciesSplit = true;
             const swalresult = await swal.fire({
                 title: 'Split Species',
-                text: 'Are you sure you want to split this species?',
+                html: '<p>Are you sure you want to split this species?</p><p class="small text-muted">Note: Splitting a species that has many occurrences can take up to a minute</p>',
                 icon: 'question',
                 showCancelButton: true,
                 confirmButtonText: 'Split Species',
@@ -1077,6 +1089,7 @@ export default {
             }));
         },
         fetchOccurrencesOfOriginalSpecies: async function () {
+            this.occurrencesLoading = true;
             const prevAssignments = { ...this.assignmentCheckedState };
             fetch(api_endpoints.occurrences_by_species_id, {
                 method: 'POST',
@@ -1090,6 +1103,7 @@ export default {
                 .then((response) => response.json())
                 .then((data) => {
                     this.occurrences = data;
+                    this.occurrencesLoading = false;
                     // Only update assignmentCheckedState for new/removed occurrences
                     const newAssignments = {};
                     this.occurrences.forEach((occurrence) => {
@@ -1102,6 +1116,7 @@ export default {
                     this.assignmentCheckedState = newAssignments;
                 })
                 .catch((error) => {
+                    this.occurrencesLoading = false;
                     console.error('Error fetching occurrences:', error);
                     this.errorString = 'Error fetching occurrences';
                 });

--- a/boranga/settings.py
+++ b/boranga/settings.py
@@ -431,7 +431,6 @@ CACHE_TIMEOUT_NEVER = None
 CACHE_KEY_EPSG_CODES = "epsg-codes-{auth_name}-{pj_type}"
 CACHE_KEY_PROXY_LAYER_DATA = "proxy-layer-data-{app_label}-{model_name}"
 CACHE_KEY_PROXY_NODE_DATA = "proxy-node-data-{request_path}"
-CACHE_KEY_MAP_OCCURRENCES = "map-occurrences"
 CACHE_KEY_MAP_OCCURRENCE_REPORTS = "map-occurrence-reports"
 CACHE_KEY_USER_BELONGS_TO_GROUP = "user-{user_id}-belongs-to-{group_name}"
 CACHE_KEY_USER_IS_REFEREE = "user-{user_id}-is-referee-{model}-{pk}"


### PR DESCRIPTION
Rename, split and combine all suffer timeouts if the underlying species has 10s of thousands of related OCCs / OCRs.

This change fixes the issue by:

- Converting those end points to use bulk insert / update for all DB operations
- Fix some issues with the loading state of front end buttons so clearly show the buttons are disabled and have a loading spinner
- Warn the user in the modal that rename, split or combine can take up to one minute for records with lots of relations

Misc

- Remove dead unused cache key delete lines for CACHE_KEY_MAP_OCCURRENCES