### PR TITLE
Dev ops task 18833: Allow greater than and less than to render in text inputs

### DIFF
--- a/boranga/components/main/models.py
+++ b/boranga/components/main/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import logging
 import os
 from abc import ABCMeta, abstractmethod
@@ -36,9 +37,10 @@ def neutralise_html(value: str) -> str:
     """
     if not value:
         return value
-    cleaned = nh3.clean(value)
-    cleaned = cleaned.replace("&amp;", "&").replace("&quot;", '"').replace("&#39;", "'")
-    return cleaned
+
+    cleaned = nh3.clean_text(value)
+
+    return html.unescape(cleaned)
 
 
 def _sanitise_json_value(value):

--- a/boranga/frontend/boranga/src/utils/vue/datatable.vue
+++ b/boranga/frontend/boranga/src/utils/vue/datatable.vue
@@ -23,6 +23,8 @@
     </div>
 </template>
 <script>
+import { helpers } from '@/utils/hooks.js';
+
 export default {
     name: 'DataTable',
     props: {
@@ -56,6 +58,21 @@ export default {
         initEvents: function () {
             let vm = this;
             let options = vm.dtOptions; // Use the original options
+
+            options.columnDefs = [
+                {
+                    // Targets ALL columns globally across the table
+                    targets: '_all',
+                    // Intercepts the data right before DataTables renders it into the <tbody>
+                    render: function (data, type) {
+                        // Only escape when rendering for the visual display (not sorting or filtering)
+                        if (type === 'display') {
+                            return helpers.escapeHtml(data);
+                        }
+                        return data;
+                    },
+                },
+            ];
 
             // Expand responsive: true into the default horizontal child-row
             // renderer so that all tables share the same layout. To change the


### PR DESCRIPTION
- Use nh3.clean_text instead of nh3.clean which was overkill
- Make sure all datatables escape html and render the plain string instead