### PR TITLE
Fix regression caused by datatable html sanitisation

### DIFF
--- a/boranga/frontend/boranga/src/utils/vue/datatable.vue
+++ b/boranga/frontend/boranga/src/utils/vue/datatable.vue
@@ -59,20 +59,16 @@ export default {
             let vm = this;
             let options = vm.dtOptions; // Use the original options
 
-            options.columnDefs = [
-                {
-                    // Targets ALL columns globally across the table
-                    targets: '_all',
-                    // Intercepts the data right before DataTables renders it into the <tbody>
-                    render: function (data, type) {
-                        // Only escape when rendering for the visual display (not sorting or filtering)
-                        if (type === 'display') {
-                            return helpers.escapeHtml(data);
-                        }
-                        return data;
-                    },
-                },
-            ];
+            if ($.fn.DataTable && $.fn.DataTable.type) {
+                $.fn.DataTable.type('string', 'render', function (data, type) {
+                    // Only escape if it's for visual display and is a string
+                    if (type === 'display' && typeof data === 'string') {
+                        // Use your existing helpers
+                        return helpers.escapeHtml(data);
+                    }
+                    return data;
+                });
+            }
 
             // Expand responsive: true into the default horizontal child-row
             // renderer so that all tables share the same layout. To change the


### PR DESCRIPTION
fix: The previous change to render was clobbering the fixed actions column styling. This way achieves the same thing without doing that.